### PR TITLE
text, textinput default props 설정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,13 @@ import { NavigationContainer } from '@react-navigation/native';
 import AuthorizeNavigator from 'navigators/AuthorizeNavigator';
 import Navigator from 'navigators/Navigator';
 import { useEffect, useState } from 'react';
-import { SafeAreaView, StyleSheet, StatusBar } from 'react-native';
+import {
+  SafeAreaView,
+  StyleSheet,
+  StatusBar,
+  Text,
+  TextInput,
+} from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import SplashScreen from 'react-native-splash-screen';
 import { colors, MyTheme } from 'styles/theme';
@@ -59,5 +65,26 @@ const App = () => {
     </QueryClientProvider>
   );
 };
+
+// 유동적 폰트 크기 제한
+interface TextWithDefaultProps extends Text {
+  defaultProps?: { allowFontScaling?: boolean };
+}
+
+(Text as unknown as TextWithDefaultProps).defaultProps =
+  (Text as unknown as TextWithDefaultProps).defaultProps || {};
+(Text as unknown as TextWithDefaultProps).defaultProps!.allowFontScaling =
+  false;
+
+interface TextInputWithDefaultProps extends TextInput {
+  defaultProps?: { allowFontScaling?: boolean; padding?: number };
+}
+
+(TextInput as unknown as TextInputWithDefaultProps).defaultProps =
+  (TextInput as unknown as TextInputWithDefaultProps).defaultProps || {};
+(
+  TextInput as unknown as TextInputWithDefaultProps
+).defaultProps!.allowFontScaling = false;
+(TextInput as unknown as TextInputWithDefaultProps).defaultProps!.padding = 0;
 
 export default App;

--- a/src/components/openEvent/atoms/OpenEvent.style.ts
+++ b/src/components/openEvent/atoms/OpenEvent.style.ts
@@ -4,7 +4,6 @@ import { colors, fonts } from 'styles/theme';
 const openEventStyles = StyleSheet.create({
   textWrapper: {
     margin: 0,
-    padding: 0,
     borderWidth: 1,
     borderRadius: 8,
     borderColor: '#B9B9B9',


### PR DESCRIPTION
<!-- ⭐️ PR 제목은 한글로 적어주세요 -->

### PR Type

<!-- 해당되는 것들을 제외하곤 지워주세요. -->

- [x] 🐛 버그수정

### OS별 테스트 여부

- [x] android
- [x] ios

### 작업 내용

<!-- 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다. -->

- text, textinput default props를 설정했습니다.

### 링크

<!-- 이슈 번호를 '#'뒤에 작성해주세요! (ex. resolved #11) -->

- resolved #46

### 기타 사항

<!-- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등이 있다면 자유롭게 적어주세요. -->

- 제가 다시 고민을 다시 해봤는데,,, 말씀드렸던 방식말고 옵션만 수정하는 방식이 더 간편해서 props만 수정했습니다!
- 사실 원래는 custom component를 만들어서 default options을 지정한 후에 사용하는 방식이 가장 좋다고 하지만
  - 수정후에 현재 사용중인 Text 컴포넌트들 다 디버깅하는 것보다, 그냥 현재 이 방법이 가장 파장이 적을 것 같아서 앱의 진입점에서 설정하도록 해놨습니다..!
- TypeCheckError때문에 아래 참고해서 수정해놨습니다!
  - [참고링크](https://github.com/GeekyAnts/NativeBase/issues/2019#issuecomment-648017458)

<!-- assignees와 reviewers를 설정했는지 확인해주세요. -->
