### PR TITLE
🔀 지도화면 개선 

### DIFF
--- a/src/components/eventMap/cards/MapEventCard/MapEventCard.tsx
+++ b/src/components/eventMap/cards/MapEventCard/MapEventCard.tsx
@@ -1,8 +1,8 @@
 import Text from 'components/common/Text/Text';
 import { memo } from 'react';
 import { Dimensions, Image, View } from 'react-native';
-import { Event } from 'types/event';
 import Carousel from 'react-native-reanimated-carousel';
+import { Event } from 'types/event';
 import mapEventCardStyles from './MapEventCard.style';
 
 interface Props {
@@ -39,7 +39,7 @@ const MapEventCard = ({ event }: Props) => {
           loop={false}
           overscrollEnabled={false}
           style={{ width: Dimensions.get('window').width - 20 }}
-          panGestureHandlerProps={{ minDist: 20 }}
+          panGestureHandlerProps={{ minDist: 10 }}
           data={event.images}
           renderItem={({ item, index }) => (
             <Image

--- a/src/components/eventMap/cards/MapEventCard/MapEventCard.tsx
+++ b/src/components/eventMap/cards/MapEventCard/MapEventCard.tsx
@@ -1,7 +1,8 @@
 import Text from 'components/common/Text/Text';
 import { memo } from 'react';
-import { Image, View } from 'react-native';
+import { Dimensions, Image, View } from 'react-native';
 import { Event } from 'types/event';
+import Carousel from 'react-native-reanimated-carousel';
 import mapEventCardStyles from './MapEventCard.style';
 
 interface Props {
@@ -32,13 +33,22 @@ const MapEventCard = ({ event }: Props) => {
         </Text>
       </View>
       <View style={mapEventCardStyles.imageContainer}>
-        {event.images.slice(0, 3).map((image) => (
-          <Image
-            key={Math.random() * 100}
-            style={mapEventCardStyles.eventImage}
-            source={{ uri: image }}
-          />
-        ))}
+        <Carousel
+          width={124}
+          height={114}
+          loop={false}
+          overscrollEnabled={false}
+          style={{ width: Dimensions.get('window').width - 20 }}
+          panGestureHandlerProps={{ minDist: 20 }}
+          data={event.images}
+          renderItem={({ item, index }) => (
+            <Image
+              key={index}
+              style={mapEventCardStyles.eventImage}
+              source={{ uri: item }}
+            />
+          )}
+        />
       </View>
     </View>
   );

--- a/src/components/eventMap/groups/SelectBoxGroup/SelectBoxGroup.tsx
+++ b/src/components/eventMap/groups/SelectBoxGroup/SelectBoxGroup.tsx
@@ -13,11 +13,15 @@ import selectBoxGroup from './SelectBoxGroup.style';
 
 interface Props {
   selectState: SelectBox;
-  dispatch: Dispatch<Action>;
+  selectDispatch: Dispatch<Action>;
   openDetailGroup: () => void;
 }
 
-const SelectBoxGroup = ({ selectState, dispatch, openDetailGroup }: Props) => {
+const SelectBoxGroup = ({
+  selectState,
+  selectDispatch,
+  openDetailGroup,
+}: Props) => {
   return (
     <View style={selectBoxGroup.selectContainer}>
       <TouchableOpacity
@@ -31,7 +35,7 @@ const SelectBoxGroup = ({ selectState, dispatch, openDetailGroup }: Props) => {
         options={payOptions}
         label="비용"
         select={(option: Option) => {
-          dispatch({
+          selectDispatch({
             type: SelectStatus.SET_PAY_OPTION,
             option,
           });
@@ -42,7 +46,7 @@ const SelectBoxGroup = ({ selectState, dispatch, openDetailGroup }: Props) => {
         options={participantOptions}
         label="참여 인원"
         select={(option: Option) => {
-          dispatch({
+          selectDispatch({
             type: SelectStatus.SET_PARTICIPANT_OPTION,
             option,
           });
@@ -53,7 +57,7 @@ const SelectBoxGroup = ({ selectState, dispatch, openDetailGroup }: Props) => {
         options={applicationAbleOptions}
         label="신청 현황"
         select={(option: Option) => {
-          dispatch({
+          selectDispatch({
             type: SelectStatus.SET_APPLICATION_ABLE_OPTION,
             option,
           });

--- a/src/components/eventMap/groups/SelectDetailGroup/SelectDetailGroup.tsx
+++ b/src/components/eventMap/groups/SelectDetailGroup/SelectDetailGroup.tsx
@@ -16,17 +16,17 @@ import selectDetailGroupStyles from './SelectDetailGroup.style';
 
 interface Props {
   selectState: SelectBox;
-  dispatch: Dispatch<Action>;
+  selectDispatch: Dispatch<Action>;
   closeDetailGroup: () => void;
 }
 
 const SelectDetailGroup = ({
   selectState,
-  dispatch,
+  selectDispatch,
   closeDetailGroup,
 }: Props) => {
   const initializeSelect = () => {
-    dispatch({ type: SelectStatus.RESET_SELECT });
+    selectDispatch({ type: SelectStatus.RESET_SELECT });
     closeDetailGroup();
   };
   const applySelect = () => {
@@ -48,7 +48,7 @@ const SelectDetailGroup = ({
         options={payOptions}
         label="비용"
         select={(option: Option) => {
-          dispatch({
+          selectDispatch({
             type: SelectStatus.SET_PAY_OPTION,
             option,
           });
@@ -60,7 +60,7 @@ const SelectDetailGroup = ({
         options={participantOptions}
         label="참여 인원"
         select={(option: Option) => {
-          dispatch({
+          selectDispatch({
             type: SelectStatus.SET_PARTICIPANT_OPTION,
             option,
           });
@@ -72,7 +72,7 @@ const SelectDetailGroup = ({
         options={applicationAbleOptions}
         label="신청 현황"
         select={(option: Option) => {
-          dispatch({
+          selectDispatch({
             type: SelectStatus.SET_APPLICATION_ABLE_OPTION,
             option,
           });

--- a/src/components/eventMap/maps/EventMarker/EventMarker.tsx
+++ b/src/components/eventMap/maps/EventMarker/EventMarker.tsx
@@ -30,7 +30,7 @@ const EventMarker = ({
       onClick={() => {
         handlePressMapCoordinate(event.id, event.coordinate);
       }}
-      pinColor={colors.background}
+      pinColor={colors.main}
     />
   );
 };

--- a/src/components/eventMap/sheets/MapBottomSheet/MapBottomSheet.tsx
+++ b/src/components/eventMap/sheets/MapBottomSheet/MapBottomSheet.tsx
@@ -25,7 +25,7 @@ interface Props {
   sort: SortInfo;
   setSort: Dispatch<SetStateAction<SortInfo>>;
   selectState: SelectBox;
-  dispatch: Dispatch<Action>;
+  selectDispatch: Dispatch<Action>;
   eventList: Event[];
   clickedMarker: string | null;
 }
@@ -37,7 +37,7 @@ const MapBottomSheet = ({
   setSort,
   selectState,
   eventList,
-  dispatch,
+  selectDispatch,
   clickedMarker,
 }: Props) => {
   const [isDetail, setIsDetail] = useState<boolean>(false);
@@ -58,7 +58,7 @@ const MapBottomSheet = ({
               <>
                 <SelectBoxGroup
                   selectState={selectState}
-                  dispatch={dispatch}
+                  selectDispatch={selectDispatch}
                   openDetailGroup={() => {
                     setIsDetail(true);
                   }}
@@ -88,7 +88,7 @@ const MapBottomSheet = ({
           >
             <SelectDetailGroup
               selectState={selectState}
-              dispatch={dispatch}
+              selectDispatch={selectDispatch}
               closeDetailGroup={() => {
                 setIsDetail(false);
               }}

--- a/src/hooks/eventMap/useEventMapSelector.tsx
+++ b/src/hooks/eventMap/useEventMapSelector.tsx
@@ -42,7 +42,7 @@ const useEventMapSelector = (eventList: Event[]) => {
     dialog: false,
     value: 'date',
   });
-  const [selectState, dispatch] = useReducer<Reducer<SelectBox, Action>>(
+  const [selectState, selectDispatch] = useReducer<Reducer<SelectBox, Action>>(
     selectReducer,
     initSelect,
   );
@@ -50,7 +50,7 @@ const useEventMapSelector = (eventList: Event[]) => {
     sort,
     setSort,
     selectState,
-    dispatch,
+    selectDispatch,
   };
 };
 

--- a/src/screens/eventMap/EventMapScreen/EventMapScreen.tsx
+++ b/src/screens/eventMap/EventMapScreen/EventMapScreen.tsx
@@ -1,7 +1,9 @@
 import {
   NavigationProp,
+  RouteProp,
   useFocusEffect,
   useNavigation,
+  useRoute,
 } from '@react-navigation/native';
 import Icon from 'components/common/Icon/Icon';
 import CurrentFindButton from 'components/eventMap/buttons/CurrentFindButton/CurrentFindButton';
@@ -13,13 +15,13 @@ import MapBottomSheet from 'components/eventMap/sheets/MapBottomSheet/MapBottomS
 import eventList from 'mocks/lists/eventList';
 import useEventMapSelector from 'hooks/eventMap/useEventMapSelector';
 import useMapCoordinateInfo from 'hooks/eventMap/useMapCoordinateInfo';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BackHandler, Dimensions, Pressable, View } from 'react-native';
 import NaverMapView, { Marker } from 'react-native-nmap';
 import { colors } from 'styles/theme';
 import { Field } from 'types/apps/group';
 import NaverMapEvent from 'types/apps/map';
-import { RootStackParamList } from 'types/apps/menu';
+import { BottomTabParamList, RootStackParamList } from 'types/apps/menu';
 import getDistanceCoordinate from 'utils/coordinate';
 import { Coordinate } from 'types/event';
 import {
@@ -27,7 +29,10 @@ import {
   eventMapScreenStyles,
 } from './EventMapScreen.style';
 
+type EventMapScreenRouteProp = RouteProp<BottomTabParamList, 'EventMap'>;
+
 const EventMapScreen = () => {
+  const { params } = useRoute<EventMapScreenRouteProp>();
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const [fieldMapMode, setFieldMapMode] = useState<Field | undefined>(
     undefined,
@@ -79,6 +84,10 @@ const EventMapScreen = () => {
       );
     });
   };
+
+  useEffect(() => {
+    console.log(params.eventId);
+  }, [params.eventId]);
 
   const recallEventMap = () => {
     navigation.setOptions({
@@ -197,7 +206,7 @@ const EventMapScreen = () => {
             width={50}
             height={50}
             coordinate={currentCoordinate}
-            pinColor="blue"
+            pinColor={colors.black}
           />
           {eventList.map((event) => (
             <EventMarker

--- a/src/types/apps/menu.ts
+++ b/src/types/apps/menu.ts
@@ -22,7 +22,9 @@ export type AuthStackParamList = {
 
 export type BottomTabParamList = {
   Home: undefined;
-  EventMap: undefined;
+  EventMap: {
+    eventId: string;
+  };
   UserEvent: undefined;
   User: undefined;
 };

--- a/src/types/apps/menu.ts
+++ b/src/types/apps/menu.ts
@@ -1,9 +1,9 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import {
   CompositeNavigationProp,
   NavigatorScreenParams,
 } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Coordinate } from 'types/event';
 import { Field } from './group';
 
@@ -23,7 +23,7 @@ export type AuthStackParamList = {
 export type BottomTabParamList = {
   Home: undefined;
   EventMap: {
-    eventId: string;
+    eventId?: string;
   };
   UserEvent: undefined;
   User: undefined;


### PR DESCRIPTION
<!-- ⭐️ PR 제목은 한글로 적어주세요 -->

### PR Type

<!-- 해당되는 것들을 제외하곤 지워주세요. -->

- [x] 💫 기능추가

### OS별 테스트 여부

- [x] android
- [x] ios

### 작업 내용

<!-- 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다. -->

- 지도 바텀시트 이미지를 3장에서 5장으로 개선했습니다.
- 이벤트 상세 페이지에서 지도화면으로 넘어오는 케이스를 고려했습니다.
- 좌표 색상을 main으로 변경하였습니다.

### 링크

<!-- 이슈 번호를 '#'뒤에 작성해주세요! (ex. resolved #11) -->

- resolved #64 

### 기타 사항

<!-- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등이 있다면 자유롭게 적어주세요. -->

- 제인이 사전에 말해주셨던 "carousel로 스크롤 이벤트가 겹치는 문제 해결하는 법"을 반영해봤어요~!

<!-- assignees와 reviewers를 설정했는지 확인해주세요. -->
