### PR TITLE
🔀 로그인 & 회원가입 API 적용하기

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,9 +7,11 @@ import {
 } from '@react-navigation/native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import DialogProvider from 'components/common/dialogs/DialogProvider';
+import FallbackError from 'components/fallback/FallbackError';
+import CommonLoading from 'components/suspense/loading/CommonLoading/CommonLoading';
 import AuthorizeNavigator from 'navigators/AuthorizeNavigator';
 import Navigator from 'navigators/Navigator';
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect } from 'react';
 import {
   SafeAreaView,
   StatusBar,
@@ -17,16 +19,15 @@ import {
   Text,
   TextInput,
 } from 'react-native';
+import ErrorBoundary from 'react-native-error-boundary';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import SplashScreen from 'react-native-splash-screen';
-import ErrorBoundary from 'react-native-error-boundary';
 import { MyTheme, colors } from 'styles/theme';
-import FallbackError from 'components/fallback/FallbackError';
-import CommonLoading from 'components/suspense/loading/CommonLoading/CommonLoading';
 
 // dayjs setting
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
+import { useAuthorizeStore } from 'stores/Authorize';
 
 dayjs.locale('ko');
 
@@ -66,7 +67,7 @@ const App = () => {
   const navigationRef = useNavigationContainerRef();
   useFlipper(navigationRef);
 
-  const [isLogin, setIsLogin] = useState<boolean>(false);
+  const { isLogin } = useAuthorizeStore();
 
   useEffect(() => {
     const timer = setTimeout(() => SplashScreen.hide(), 2000);
@@ -88,11 +89,7 @@ const App = () => {
                   {/* <StorybookUIRoot /> */}
                   {/* 스토리북 실행을 원한다면 위 주석해제, 아래 주석처리 */}
                   <StatusBar backgroundColor={colors.background} />
-                  {isLogin ? (
-                    <Navigator />
-                  ) : (
-                    <AuthorizeNavigator setIsLogin={setIsLogin} />
-                  )}
+                  {isLogin ? <Navigator /> : <AuthorizeNavigator />}
                 </NavigationContainer>
               </GestureHandlerRootView>
             </SafeAreaView>

--- a/App.tsx
+++ b/App.tsx
@@ -75,28 +75,28 @@ const App = () => {
   }, []);
 
   return (
-    <DialogProvider>
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary FallbackComponent={FallbackError}>
-          <Suspense
-            fallback={
-              <CommonLoading isActive backgroundColor={colors.background} />
-            }
-          >
-            <SafeAreaView style={appStyles.safeAreaContainer}>
-              <GestureHandlerRootView style={appStyles.gestureContainer}>
-                <NavigationContainer theme={MyTheme} ref={navigationRef}>
+    <QueryClientProvider client={queryClient}>
+      <ErrorBoundary FallbackComponent={FallbackError}>
+        <Suspense
+          fallback={
+            <CommonLoading isActive backgroundColor={colors.background} />
+          }
+        >
+          <SafeAreaView style={appStyles.safeAreaContainer}>
+            <GestureHandlerRootView style={appStyles.gestureContainer}>
+              <NavigationContainer theme={MyTheme} ref={navigationRef}>
+                <DialogProvider>
                   {/* <StorybookUIRoot /> */}
                   {/* 스토리북 실행을 원한다면 위 주석해제, 아래 주석처리 */}
                   <StatusBar backgroundColor={colors.background} />
                   {isLogin ? <Navigator /> : <AuthorizeNavigator />}
-                </NavigationContainer>
-              </GestureHandlerRootView>
-            </SafeAreaView>
-          </Suspense>
-        </ErrorBoundary>
-      </QueryClientProvider>
-    </DialogProvider>
+                </DialogProvider>
+              </NavigationContainer>
+            </GestureHandlerRootView>
+          </SafeAreaView>
+        </Suspense>
+      </ErrorBoundary>
+    </QueryClientProvider>
   );
 };
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,15 @@
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/AppTheme" android:allowBackup="true">
+  <application 
+    android:hardwareAccelerated="false"
+    android:largeHeap="true" 
+    android:name=".MainApplication" 
+    android:label="@string/app_name" 
+    android:icon="@mipmap/ic_launcher" 
+    android:roundIcon="@mipmap/ic_launcher_round" 
+    android:theme="@style/AppTheme" 
+    android:allowBackup="true">
     <meta-data android:name="com.naver.maps.map.CLIENT_ID" android:value="@string/REACT_APP_NAVER_MAP_KEY" />
     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="true">
       <intent-filter>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=1024m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,12 +1,56 @@
 import fetcher from 'apis';
-import { ApiResponse } from 'types/ApiResponse';
 import { NormalSignInRequestDto } from 'models/auth/request/NormalSignInRequestDto';
+import { SocialSignupRequestDto } from 'models/auth/request/SocialSignupRequestDto';
+import { TokenRequestDto } from 'models/auth/request/TokenRequestDto';
+import { CheckEmailResponseDto } from 'models/auth/response/CheckEmailResponseDto';
 import { TokenResponseDto } from 'models/auth/response/TokenResponseDto';
+import { useAuthorizeStore } from 'stores/Authorize';
+import { ApiResponse } from 'types/ApiResponse';
 
-// eslint-disable-next-line import/prefer-default-export
+const { token } = useAuthorizeStore.getState();
+
 export const normalLogin = async (
   data: NormalSignInRequestDto,
 ): Promise<ApiResponse<TokenResponseDto>> => {
   const response = await fetcher.post(`auth/login/normal`, data);
+  return response.data;
+};
+
+export const normalSignUp = async (
+  data: NormalSignInRequestDto,
+): Promise<ApiResponse<TokenResponseDto>> => {
+  const response = await fetcher.post(`/auth/signup/normal`, data);
+  return response.data;
+};
+
+export const refresh = async (): Promise<ApiResponse<TokenResponseDto>> => {
+  const params: TokenRequestDto = {
+    accessToken: token.accessToken,
+    refreshToken: token.refreshToken,
+  };
+  const response = await fetcher.post(`auth/refresh`, params);
+  return response.data;
+};
+
+export const socialLogin = async (
+  data: SocialSignupRequestDto,
+): Promise<ApiResponse<TokenResponseDto>> => {
+  const params = {
+    token: data.token,
+  };
+  const response = await fetcher.post(
+    `/auth/signup/social/${data.socialType}`,
+    params,
+  );
+  return response.data;
+};
+
+export const checkEmail = async (
+  email: string,
+): Promise<ApiResponse<CheckEmailResponseDto>> => {
+  const params = {
+    email,
+  };
+  const response = await fetcher.get(`/auth/check/email`, { params });
   return response.data;
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -3,6 +3,7 @@ import { NormalSignInRequestDto } from 'models/auth/request/NormalSignInRequestD
 import { SocialSignupRequestDto } from 'models/auth/request/SocialSignupRequestDto';
 import { TokenRequestDto } from 'models/auth/request/TokenRequestDto';
 import { CheckEmailResponseDto } from 'models/auth/response/CheckEmailResponseDto';
+import { CheckNicknameResponseDto } from 'models/auth/response/CheckNicknameResponseDto';
 import { TokenResponseDto } from 'models/auth/response/TokenResponseDto';
 import { useAuthorizeStore } from 'stores/Authorize';
 import { ApiResponse } from 'types/ApiResponse';
@@ -52,5 +53,15 @@ export const checkEmail = async (
     email,
   };
   const response = await fetcher.get(`/auth/check/email`, { params });
+  return response.data;
+};
+
+export const checkNickname = async (
+  nickname: string,
+): Promise<ApiResponse<CheckNicknameResponseDto>> => {
+  const params = {
+    nickname,
+  };
+  const response = await fetcher.get(`/auth/check/nickname`, { params });
   return response.data;
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -85,12 +85,12 @@ export const checkAuthSms = async (
 };
 
 export const searchEmail = async (
-  email: string,
+  phoneNum: string,
 ): Promise<ApiResponse<SearchIdResponseDto>> => {
   const params = {
-    id: email,
+    phoneNum,
   };
-  const response = await fetcher.get('/auth/searh/id', { params });
+  const response = await fetcher.get('/auth/search/id', { params });
   return response.data;
 };
 

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,10 +1,14 @@
 import fetcher from 'apis';
 import { NormalSignInRequestDto } from 'models/auth/request/NormalSignInRequestDto';
+import ResetPasswordRequestDto from 'models/auth/request/ResetPasswordRequestDto';
 import { SocialSignupRequestDto } from 'models/auth/request/SocialSignupRequestDto';
 import { TokenRequestDto } from 'models/auth/request/TokenRequestDto';
 import { CheckEmailResponseDto } from 'models/auth/response/CheckEmailResponseDto';
 import { CheckNicknameResponseDto } from 'models/auth/response/CheckNicknameResponseDto';
+import SearchIdResponseDto from 'models/auth/response/SearchIdResponseDto';
 import { TokenResponseDto } from 'models/auth/response/TokenResponseDto';
+import NCPSmsInfoRequestDto from 'models/user/request/NCPSmsInfoRequestDto';
+import UserSmsCheckRequestDto from 'models/user/request/UserSmsCheckRequestDto';
 import { useAuthorizeStore } from 'stores/Authorize';
 import { ApiResponse } from 'types/ApiResponse';
 
@@ -20,7 +24,7 @@ export const normalLogin = async (
 export const normalSignUp = async (
   data: NormalSignInRequestDto,
 ): Promise<ApiResponse<TokenResponseDto>> => {
-  const response = await fetcher.post(`/auth/signup/normal`, data);
+  const response = await fetcher.post(`auth/signup/normal`, data);
   return response.data;
 };
 
@@ -52,7 +56,7 @@ export const checkEmail = async (
   const params = {
     email,
   };
-  const response = await fetcher.get(`/auth/check/email`, { params });
+  const response = await fetcher.get(`auth/check/email`, { params });
   return response.data;
 };
 
@@ -62,6 +66,37 @@ export const checkNickname = async (
   const params = {
     nickname,
   };
-  const response = await fetcher.get(`/auth/check/nickname`, { params });
+  const response = await fetcher.get(`auth/check/nickname`, { params });
+  return response.data;
+};
+
+export const sendAuthSms = async (
+  data: NCPSmsInfoRequestDto,
+): Promise<ApiResponse> => {
+  const response = await fetcher.post(`auth/sms`, data);
+  return response.data;
+};
+
+export const checkAuthSms = async (
+  data: UserSmsCheckRequestDto,
+): Promise<ApiResponse> => {
+  const response = await fetcher.patch(`auth/sms`, data);
+  return response.data;
+};
+
+export const searchEmail = async (
+  email: string,
+): Promise<ApiResponse<SearchIdResponseDto>> => {
+  const params = {
+    id: email,
+  };
+  const response = await fetcher.get('/auth/searh/id', { params });
+  return response.data;
+};
+
+export const resetPassword = async (
+  data: ResetPasswordRequestDto,
+): Promise<ApiResponse> => {
+  const response = await fetcher.patch('/auth/reset/password', data);
   return response.data;
 };

--- a/src/apis/field.ts
+++ b/src/apis/field.ts
@@ -1,0 +1,11 @@
+import fetcher from 'apis';
+import AddInterestRequestDto from 'models/field/request/AddInterestRequestDto';
+import { ApiResponse } from 'types/ApiResponse';
+
+// eslint-disable-next-line import/prefer-default-export
+export const updateInterestField = async (
+  data: AddInterestRequestDto,
+): Promise<ApiResponse> => {
+  const response = await fetcher.post(`field/save`, data);
+  return response.data;
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,7 +1,12 @@
 /* eslint-disable no-return-assign */
 import axios, { AxiosResponse } from 'axios';
 import Config from 'react-native-config';
+import { useAuthorizeStore } from 'stores/Authorize';
 import { ApiErrorResponse } from 'types/ApiResponse';
+import { refresh } from './auth';
+
+const { token, setIsLogin, resetToken, setToken } =
+  useAuthorizeStore.getState();
 
 const baseURL = Config.OPENOFF_PROD_SERVER;
 
@@ -26,6 +31,13 @@ const onFulfilled = (res: AxiosResponse) => {
 
 let isTokenRenewalInProgress = false;
 
+const initializeAuthorizeState = (error?: unknown) => {
+  resetToken();
+  setIsLogin(false);
+  isTokenRenewalInProgress = false;
+  return Promise.reject(error);
+};
+
 const onRejected = async (error: ApiErrorResponse) => {
   const originalRequest = error.config;
   const data = error.response?.data;
@@ -39,21 +51,24 @@ const onRejected = async (error: ApiErrorResponse) => {
     isTokenRenewalInProgress = true;
 
     try {
-      // 1. refresh token 가져오기
-      // 1-1. refresh token이 없다면, 로그아웃
-      // 1-2. refresh token이 있다면 refresh
-      // const accessToken = await refresh();
+      if (!token.refreshToken) {
+        initializeAuthorizeState();
+      }
 
-      // 2. 새로 받아온 access token으로 재시도
-      // originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+      if (token.refreshToken) {
+        const accessToken = await refresh();
+        originalRequest.headers.Authorization = `Bearer ${accessToken.data?.accessToken}`;
+        setToken({
+          accessToken: accessToken.data?.accessToken,
+          refreshToken: accessToken.data?.refreshToken,
+        });
+      }
+
       const response = await fetcher.request(originalRequest);
       isTokenRenewalInProgress = false;
       return response;
     } catch (refreshError) {
-      console.log(refreshError);
-      // 로그아웃
-      isTokenRenewalInProgress = false;
-      return Promise.reject(refreshError);
+      initializeAuthorizeState(refreshError);
     }
   }
   return Promise.reject(error);

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -34,6 +34,7 @@ let isTokenRenewalInProgress = false;
 const initializeAuthorizeState = (error?: unknown) => {
   resetToken();
   setIsLogin(false);
+  fetcher.defaults.headers.Authorization = null;
   isTokenRenewalInProgress = false;
   return Promise.reject(error);
 };

--- a/src/apis/interest.ts
+++ b/src/apis/interest.ts
@@ -6,6 +6,6 @@ import { ApiResponse } from 'types/ApiResponse';
 export const updateInterestField = async (
   data: AddInterestRequestDto,
 ): Promise<ApiResponse> => {
-  const response = await fetcher.post(`field/save`, data);
+  const response = await fetcher.post(`interest/save`, data);
   return response.data;
 };

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,0 +1,34 @@
+import fetcher from 'apis';
+import NCPSmsInfoRequestDto from 'models/user/request/NCPSmsInfoRequestDto';
+import UserOnboardingRequestDto from 'models/user/request/UserOnboardingRequestDto';
+import UserSmsCheckRequestDto from 'models/user/request/UserSmsCheckRequestDto';
+import UserTotalInfoResponseDto from 'models/user/response/UserTotalInfoResponseDto';
+import { ApiResponse } from 'types/ApiResponse';
+
+export const getMyInfo = async (): Promise<
+  ApiResponse<UserTotalInfoResponseDto>
+> => {
+  const response = await fetcher.get('user/my/info');
+  return response.data;
+};
+
+export const sendSms = async (
+  data: NCPSmsInfoRequestDto,
+): Promise<ApiResponse> => {
+  const response = await fetcher.post(`user/sms`, data);
+  return response.data;
+};
+
+export const checkSms = async (
+  data: UserSmsCheckRequestDto,
+): Promise<ApiResponse> => {
+  const response = await fetcher.patch(`user/sms`, data);
+  return response.data;
+};
+
+export const updateOnBoarding = async (
+  data: UserOnboardingRequestDto,
+): Promise<ApiResponse> => {
+  const response = await fetcher.patch(`user/onboarding`, data);
+  return response.data;
+};

--- a/src/components/authorize/buttons/BackToHomeButton/BackToHomeButton.tsx
+++ b/src/components/authorize/buttons/BackToHomeButton/BackToHomeButton.tsx
@@ -1,17 +1,11 @@
 import Icon from 'components/common/Icon/Icon';
+import { useCallback } from 'react';
 import { TouchableOpacity } from 'react-native';
-import React, { useCallback } from 'react';
-import useNavigator from 'hooks/navigator/useNavigator';
-import { AuthorizeMenu } from 'constants/menu';
-import { useNavigation, NavigationProp } from '@react-navigation/native';
-import { AuthStackParamList } from 'types/apps/menu';
+import { useAuthorizeStore } from 'stores/Authorize';
 import backToLoginButtonStyles from './BackToHomeButton.style';
 
-interface Props {
-  setIsLogin: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-const BackToHomeButton = ({ setIsLogin }: Props) => {
+const BackToHomeButton = () => {
+  const { setIsLogin } = useAuthorizeStore();
   const handlePress = useCallback(() => {
     setIsLogin(true);
   }, []);

--- a/src/components/authorize/buttons/CheckButton/CheckButton.style.ts
+++ b/src/components/authorize/buttons/CheckButton/CheckButton.style.ts
@@ -1,4 +1,5 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, TextStyle } from 'react-native';
+import { fonts } from 'styles/theme';
 
 const checkButtonStyles = StyleSheet.create({
   container: {
@@ -17,9 +18,8 @@ const checkButtonStyles = StyleSheet.create({
   },
   checkButtonLabel: {
     fontSize: 17,
-    color: '#FFF',
-    fontWeight: '600',
-  },
+    fontFamily: fonts.semibold,
+  } as TextStyle,
 });
 
 export default checkButtonStyles;

--- a/src/components/authorize/buttons/CheckButton/CheckButton.tsx
+++ b/src/components/authorize/buttons/CheckButton/CheckButton.tsx
@@ -32,9 +32,7 @@ const CheckButton = ({
           }
         />
       </TouchableOpacity>
-      <Text variant="h4" color="white">
-        {label}
-      </Text>
+      <Text style={checkButtonStyles.checkButtonLabel}>{label}</Text>
     </View>
   );
 };

--- a/src/components/authorize/buttons/ColorButton/ColorButton.style.ts
+++ b/src/components/authorize/buttons/ColorButton/ColorButton.style.ts
@@ -2,14 +2,11 @@ import { StyleSheet } from 'react-native';
 
 const colorButtonStyles = StyleSheet.create({
   container: {
-    maxWidth: 300,
-    minWidth: 80,
-    height: 35,
     borderRadius: 20,
-    paddingHorizontal: 10,
+    paddingHorizontal: 24,
+    paddingVertical: 10,
     justifyContent: 'center',
     alignItems: 'center',
-    flexDirection: 'row',
     borderWidth: 1,
   },
   labelText: {

--- a/src/components/authorize/buttons/ColorButton/ColorButton.tsx
+++ b/src/components/authorize/buttons/ColorButton/ColorButton.tsx
@@ -26,6 +26,7 @@ const ColorButton = ({
 }: Props) => {
   return (
     <TouchableOpacity
+      activeOpacity={0.8}
       style={{
         ...colorButtonStyles.container,
         backgroundColor,

--- a/src/components/authorize/buttons/JoinAndFindButton/JoinAndFindButton.style.ts
+++ b/src/components/authorize/buttons/JoinAndFindButton/JoinAndFindButton.style.ts
@@ -1,4 +1,5 @@
-import { StyleSheet } from 'react-native';
+import { fonts } from 'styles/theme';
+import { StyleSheet, TextStyle } from 'react-native';
 
 const joinAndFindButtonStyle = StyleSheet.create({
   container: {
@@ -8,6 +9,10 @@ const joinAndFindButtonStyle = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  text: {
+    fontFamily: fonts.regular,
+    fontSize: 13,
+  } as TextStyle,
 });
 
 export default joinAndFindButtonStyle;

--- a/src/components/authorize/buttons/JoinAndFindButton/JoinAndFindButton.tsx
+++ b/src/components/authorize/buttons/JoinAndFindButton/JoinAndFindButton.tsx
@@ -11,20 +11,18 @@ const JoinAndFindButton = () => {
   return (
     <View style={joinAndFindButtonStyle.container}>
       <TouchableOpacity
+        activeOpacity={0.8}
         style={joinAndFindButtonStyle.buttonContainer}
         onPress={() => navigation.navigate(AuthorizeMenu.EmailPassword)}
       >
-        <Text variant="caption" color="white">
-          회원가입
-        </Text>
+        <Text style={joinAndFindButtonStyle.text}>회원가입</Text>
       </TouchableOpacity>
-      <Text variant="caption" color="white">{`   |   `}</Text>
+      <Text style={joinAndFindButtonStyle.text}>{`   |   `}</Text>
       <TouchableOpacity
+        activeOpacity={0.8}
         onPress={() => navigation.navigate(AuthorizeMenu.EmailPasswordFind)}
       >
-        <Text variant="caption" color="white">
-          아이디/비밀번호 찾기
-        </Text>
+        <Text style={joinAndFindButtonStyle.text}>아이디/비밀번호 찾기</Text>
       </TouchableOpacity>
     </View>
   );

--- a/src/components/authorize/buttons/LoginButton/LoginButton.style.ts
+++ b/src/components/authorize/buttons/LoginButton/LoginButton.style.ts
@@ -3,11 +3,10 @@ import { StyleSheet } from 'react-native';
 const loginButtonStyles = StyleSheet.create({
   container: {
     borderRadius: 27.5,
-    marginTop: 40,
-    width: '100%',
-    height: 55,
+    paddingVertical: 15,
     justifyContent: 'center',
     alignItems: 'center',
+    marginTop: 15,
   },
 });
 

--- a/src/components/authorize/buttons/LoginButton/LoginButton.tsx
+++ b/src/components/authorize/buttons/LoginButton/LoginButton.tsx
@@ -11,6 +11,7 @@ interface Props {
 const LoginButton = ({ handlePress, isActive }: Props) => {
   return (
     <TouchableOpacity
+      activeOpacity={0.7}
       onPress={handlePress}
       style={{
         ...loginButtonStyles.container,

--- a/src/components/authorize/buttons/PhoneAuthButton/PhoneAuthButton.style.ts
+++ b/src/components/authorize/buttons/PhoneAuthButton/PhoneAuthButton.style.ts
@@ -1,27 +1,25 @@
-import { StyleSheet } from 'react-native';
-import { colors } from 'styles/theme';
+import { StyleSheet, TextStyle } from 'react-native';
+import { colors, fonts } from 'styles/theme';
 
 const phoneAuthButtonStyles = StyleSheet.create({
-  activeButton: {
-    width: 80,
-    height: 40,
-    marginLeft: 5,
+  buttonWrapper: {
+    marginTop: 5,
+    paddingHorizontal: 17,
+    paddingVertical: 12,
     borderRadius: 27.5,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'transparent',
-    borderColor: colors.white,
     borderWidth: 1,
   },
-  nonActiveButton: {
-    width: 80,
-    height: 40,
-    marginLeft: 10,
-    borderRadius: 27.5,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: colors.darkGrey,
+  activeButton: {
+    borderColor: colors.white,
   },
+  nonActiveButton: {
+    backgroundColor: colors.darkGrey,
+    borderColor: colors.darkGrey,
+  },
+  text: {
+    fontFamily: fonts.semibold,
+    fontSize: 13,
+  } as TextStyle,
 });
 
 export default phoneAuthButtonStyles;

--- a/src/components/authorize/buttons/PhoneAuthButton/PhoneAuthButton.style.ts
+++ b/src/components/authorize/buttons/PhoneAuthButton/PhoneAuthButton.style.ts
@@ -1,9 +1,13 @@
-import { StyleSheet, TextStyle } from 'react-native';
+import { Platform, StyleSheet, TextStyle } from 'react-native';
+import { getPixelSize } from 'styles/styleUtils';
 import { colors, fonts } from 'styles/theme';
 
 const phoneAuthButtonStyles = StyleSheet.create({
   buttonWrapper: {
-    marginTop: 5,
+    marginTop: Platform.select({
+      android: getPixelSize(5),
+      ios: 5,
+    }),
     paddingHorizontal: 17,
     paddingVertical: 12,
     borderRadius: 27.5,

--- a/src/components/authorize/buttons/PhoneAuthButton/PhoneAuthButton.tsx
+++ b/src/components/authorize/buttons/PhoneAuthButton/PhoneAuthButton.tsx
@@ -15,14 +15,19 @@ const PhoneAuthButton = ({ label, active, handlePress }: Props) => {
   };
   return (
     <TouchableOpacity
-      style={
+      activeOpacity={0.8}
+      style={[
+        phoneAuthButtonStyles.buttonWrapper,
         active
           ? phoneAuthButtonStyles.activeButton
-          : phoneAuthButtonStyles.nonActiveButton
-      }
+          : phoneAuthButtonStyles.nonActiveButton,
+      ]}
       onPress={hadleAuthPress}
     >
-      <Text variant="caption" color={active ? 'white' : 'grey'}>
+      <Text
+        color={active ? 'white' : 'grey'}
+        style={phoneAuthButtonStyles.text}
+      >
         {label}
       </Text>
     </TouchableOpacity>

--- a/src/components/authorize/buttons/SocialLoginButton/SocialLoginButton.style.ts
+++ b/src/components/authorize/buttons/SocialLoginButton/SocialLoginButton.style.ts
@@ -4,7 +4,6 @@ const socialLoginButtonStyles = StyleSheet.create({
   container: {
     width: 60,
     height: 60,
-    margin: 15,
     borderRadius: 200,
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/components/authorize/covers/ScreenCover/ScreenCover.style.ts
+++ b/src/components/authorize/covers/ScreenCover/ScreenCover.style.ts
@@ -5,6 +5,7 @@ const screenCoverStyles = StyleSheet.create({
     flex: 1,
   },
   scrollContainer: {
+    paddingTop: 25,
     paddingHorizontal: 25,
   },
 });

--- a/src/components/authorize/groups/FieldButtonGroup/FieldButtonGroup.style.ts
+++ b/src/components/authorize/groups/FieldButtonGroup/FieldButtonGroup.style.ts
@@ -1,9 +1,9 @@
 import { StyleSheet } from 'react-native';
+import { fonts } from 'styles/theme';
 
 const fieldButtonGroupStyles = StyleSheet.create({
   container: {
-    flexDirection: 'column',
-    marginTop: 20,
+    gap: 10,
   },
   fieldContainer: {
     width: 360,
@@ -12,9 +12,7 @@ const fieldButtonGroupStyles = StyleSheet.create({
   },
   title: {
     fontSize: 12,
-    color: '#FFF',
-    width: 360,
-    marginBottom: 7,
+    fontFamily: fonts.semibold,
   },
 });
 

--- a/src/components/authorize/groups/FieldButtonGroup/FieldButtonGroup.tsx
+++ b/src/components/authorize/groups/FieldButtonGroup/FieldButtonGroup.tsx
@@ -1,6 +1,7 @@
+import Text from 'components/common/Text/Text';
 import FieldButton from 'components/authorize/buttons/FieldButton/FieldButton';
 import { Dispatch, SetStateAction } from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 import { Field } from 'types/apps/group';
 import fieldButtonGroupStyles from './FieldButtonGroup.style';
 

--- a/src/components/authorize/groups/SocialLoginButtonGroup/SocialLoginButtonGroup.style.ts
+++ b/src/components/authorize/groups/SocialLoginButtonGroup/SocialLoginButtonGroup.style.ts
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 const socialLoginButtonGroupStyles = StyleSheet.create({
   container: {
     flexDirection: 'row',
+    justifyContent: 'space-evenly',
   },
   socialLogo: {
     width: 40,

--- a/src/components/authorize/inputs/BaseInfoInput/BaseInfoInput.style.ts
+++ b/src/components/authorize/inputs/BaseInfoInput/BaseInfoInput.style.ts
@@ -7,6 +7,7 @@ const baseInfoInputStyles = StyleSheet.create({
     position: 'relative',
   },
   input: {
+    marginTop: 5,
     width: '100%',
     fontSize: 15,
     paddingVertical: 10,

--- a/src/components/authorize/inputs/BaseInfoInput/BaseInfoInput.style.ts
+++ b/src/components/authorize/inputs/BaseInfoInput/BaseInfoInput.style.ts
@@ -1,25 +1,21 @@
-import { Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet, TextStyle } from 'react-native';
+import textStyles from 'styles/textStyles';
 import { fonts } from 'styles/theme';
 
 const baseInfoInputStyles = StyleSheet.create({
   container: {
-    flexDirection: 'column',
-    position: 'relative',
+    flex: 1,
   },
-  input: {
-    marginTop: 5,
-    width: '100%',
-    fontSize: 15,
-    paddingVertical: 10,
+  labelText: {
     fontFamily: fonts.semibold,
+    fontSize: 18,
+  } as TextStyle,
+  input: {
+    flex: 1,
+    paddingVertical: 6,
     borderBottomWidth: 1,
     backgroundColor: 'transparent',
-  },
-  inputTitle: {
-    color: 'white',
-    fontSize: 18,
-    marginBottom: Platform.OS === 'android' ? 10 : 14,
-    fontWeight: '600',
+    ...textStyles.body1,
   },
   resetPosition: {
     position: 'relative',
@@ -28,6 +24,13 @@ const baseInfoInputStyles = StyleSheet.create({
   resetImage: {
     width: 18,
     height: 18,
+  },
+  inputContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    alignItems: 'center',
+    gap: 5,
   },
 });
 

--- a/src/components/authorize/inputs/BaseInfoInput/BaseInfoInput.tsx
+++ b/src/components/authorize/inputs/BaseInfoInput/BaseInfoInput.tsx
@@ -1,5 +1,6 @@
 import ErrorText from 'components/authorize/texts/ErrorText/ErrorText';
 import Icon from 'components/common/Icon/Icon';
+import Text from 'components/common/Text/Text';
 import { Dispatch, SetStateAction, useState } from 'react';
 import {
   GestureResponderEvent,
@@ -8,7 +9,6 @@ import {
   View,
 } from 'react-native';
 import DatePicker from 'react-native-date-picker';
-import Text from 'components/common/Text/Text';
 import { TextInput } from 'react-native-gesture-handler';
 import { colors } from 'styles/theme';
 import { dateFormatter } from 'utils/date';
@@ -42,19 +42,8 @@ const BaseInfoInput = ({
         <Text variant="h4" color="white" style={{ width }}>
           {label}
         </Text>
-        <Pressable
-          onPressIn={
-            focusMode
-              ? () => {
-                  setOpen(true);
-                }
-              : () => {
-                  return false;
-                }
-          }
-        >
+        {!focusMode ? (
           <TextInput
-            editable={!focusMode}
             value={value}
             style={{
               ...baseInfoInputStyles.input,
@@ -62,9 +51,22 @@ const BaseInfoInput = ({
               color: validation(value) ? colors.error : colors.white,
               borderColor: validation(value) ? colors.error : colors.main,
             }}
-            onChangeText={(value) => setValue(value)}
+            onChangeText={(inputValue) => setValue(inputValue)}
           />
-        </Pressable>
+        ) : (
+          <Pressable onPress={() => setOpen(true)}>
+            <Text
+              style={{
+                ...baseInfoInputStyles.input,
+                width,
+                color: validation(value) ? colors.error : colors.white,
+                borderColor: validation(value) ? colors.error : colors.main,
+              }}
+            >
+              {value}
+            </Text>
+          </Pressable>
+        )}
         <View
           style={{ ...baseInfoInputStyles.resetPosition, left: width - 18 }}
         >

--- a/src/components/authorize/inputs/BaseInfoInput/BaseInfoInput.tsx
+++ b/src/components/authorize/inputs/BaseInfoInput/BaseInfoInput.tsx
@@ -12,12 +12,12 @@ import DatePicker from 'react-native-date-picker';
 import { TextInput } from 'react-native-gesture-handler';
 import { colors } from 'styles/theme';
 import { dateFormatter } from 'utils/date';
+import Spacing from 'components/common/Spacing/Spacing';
 import baseInfoInputStyles from './BaseInfoInput.style';
 
 interface Props {
   label: string;
   value: string;
-  width: number;
   setValue: Dispatch<SetStateAction<string>>;
   validation: (value: string) => string | undefined;
   focusMode?: boolean;
@@ -28,7 +28,6 @@ const BaseInfoInput = ({
   value,
   setValue,
   validation,
-  width,
   focusMode = false,
 }: Props) => {
   const [open, setOpen] = useState<boolean>(false);
@@ -38,46 +37,53 @@ const BaseInfoInput = ({
   };
   return (
     <>
-      <View style={{ ...baseInfoInputStyles.container, width }}>
-        <Text variant="h4" color="white" style={{ width }}>
-          {label}
-        </Text>
-        {!focusMode ? (
-          <TextInput
-            value={value}
-            style={{
-              ...baseInfoInputStyles.input,
-              width,
-              color: validation(value) ? colors.error : colors.white,
-              borderColor: validation(value) ? colors.error : colors.main,
-            }}
-            onChangeText={(inputValue) => setValue(inputValue)}
-          />
-        ) : (
-          <Pressable onPress={() => setOpen(true)}>
-            <Text
+      <View style={baseInfoInputStyles.container}>
+        <Text style={{ ...baseInfoInputStyles.labelText }}>{label}</Text>
+        <Spacing height={20} />
+
+        <View
+          style={[
+            baseInfoInputStyles.inputContainer,
+            {
+              borderBottomColor: validation(value) ? colors.error : colors.main,
+            },
+          ]}
+        >
+          {!focusMode ? (
+            <TextInput
+              value={value}
               style={{
                 ...baseInfoInputStyles.input,
-                width,
                 color: validation(value) ? colors.error : colors.white,
-                borderColor: validation(value) ? colors.error : colors.main,
               }}
+              onChangeText={(inputValue) => setValue(inputValue)}
+            />
+          ) : (
+            <Pressable
+              style={baseInfoInputStyles.input}
+              onPress={() => setOpen(true)}
             >
-              {value}
-            </Text>
-          </Pressable>
-        )}
-        <View
-          style={{ ...baseInfoInputStyles.resetPosition, left: width - 18 }}
-        >
+              <Text
+                variant="body1"
+                style={{
+                  color: validation(value) ? colors.error : colors.white,
+                }}
+              >
+                {value}
+              </Text>
+            </Pressable>
+          )}
+
           <TouchableOpacity onPress={resetValue}>
             <Icon name="IconExitCircle" size={18} fill="main" />
           </TouchableOpacity>
         </View>
-        {!focusMode && (
-          <ErrorText validation={validation} value={value} width={width} />
-        )}
+
+        <Spacing height={5} />
+
+        {!focusMode && <ErrorText validation={validation} value={value} />}
       </View>
+
       {focusMode && (
         <DatePicker
           modal

--- a/src/components/authorize/inputs/EssentialInput/EssentialInput.style.ts
+++ b/src/components/authorize/inputs/EssentialInput/EssentialInput.style.ts
@@ -1,40 +1,40 @@
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { fonts } from 'styles/theme';
 
 const essentialInputStyles = StyleSheet.create({
   container: {
-    flexDirection: 'row',
-    marginBottom: 20,
+    flex: 1,
+    marginBottom: 15,
   },
   inputContainer: {
-    paddingVertical: 10,
-    paddingHorizontal: 20,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
     borderRadius: 8,
     borderWidth: 1.5,
     fontSize: 15,
     fontFamily: fonts.semibold,
   },
   inputAbsoluteContainer: {
-    position: 'relative',
-  },
-  phoneInputContainer: {
-    flexDirection: 'column',
+    flex: 1,
   },
   phoneInputRow: {
     flexDirection: 'row',
-    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
   },
   label: {
     fontFamily: fonts.semibold,
     fontSize: 15,
-    alignItems: 'flex-start',
-    width: '100%',
-    marginBottom: 4,
+    marginBottom: 5,
   },
   validateStatus: {
     position: 'absolute',
-    top: Platform.OS === 'android' ? 15 : 8,
-    right: 10,
+    top: 14,
+    right: 16,
+  },
+  helpTextContainer: {
+    marginTop: 5,
+    flex: 1,
   },
 });
 

--- a/src/components/authorize/inputs/EssentialInput/EssentialInput.style.ts
+++ b/src/components/authorize/inputs/EssentialInput/EssentialInput.style.ts
@@ -1,4 +1,5 @@
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
+import { getPixelSize } from 'styles/styleUtils';
 import { fonts } from 'styles/theme';
 
 const essentialInputStyles = StyleSheet.create({
@@ -7,7 +8,11 @@ const essentialInputStyles = StyleSheet.create({
     marginBottom: 15,
   },
   inputContainer: {
-    paddingVertical: 14,
+    margin: 0,
+    paddingVertical: Platform.select({
+      android: getPixelSize(14),
+      ios: 14,
+    }),
     paddingHorizontal: 16,
     borderRadius: 8,
     borderWidth: 1.5,
@@ -29,7 +34,10 @@ const essentialInputStyles = StyleSheet.create({
   },
   validateStatus: {
     position: 'absolute',
-    top: 14,
+    top: Platform.select({
+      android: 8,
+      ios: 14,
+    }),
     right: 16,
   },
   helpTextContainer: {

--- a/src/components/authorize/inputs/EssentialInput/EssentialInput.tsx
+++ b/src/components/authorize/inputs/EssentialInput/EssentialInput.tsx
@@ -1,8 +1,9 @@
 import ErrorText from 'components/authorize/texts/ErrorText/ErrorText';
 import Icon from 'components/common/Icon/Icon';
 import Text from 'components/common/Text/Text';
+import Spacing from 'components/common/Spacing/Spacing';
 import React, { Dispatch, ReactNode, SetStateAction } from 'react';
-import { Dimensions, TextInput, View } from 'react-native';
+import { TextInput, View } from 'react-native';
 import { colors } from 'styles/theme';
 import essentialInputStyles from './EssentialInput.style';
 
@@ -27,10 +28,6 @@ const EssentialInput = ({
   maxLength = 20,
   ...rest
 }: Props) => {
-  const clacWidth =
-    children && type === 'phonenumber'
-      ? Dimensions.get('window').width - 140
-      : Dimensions.get('window').width - 50;
   const handleChangeText = (
     textValue: string,
     onChange: Dispatch<SetStateAction<string>>,
@@ -48,49 +45,49 @@ const EssentialInput = ({
   };
   return (
     <View style={essentialInputStyles.container}>
-      <View style={essentialInputStyles.phoneInputContainer}>
-        <Text color="grey" style={essentialInputStyles.label}>
-          {label}
-        </Text>
-        <View style={essentialInputStyles.phoneInputRow}>
-          <View style={essentialInputStyles.inputAbsoluteContainer}>
-            <TextInput
-              value={value}
-              maxLength={maxLength}
-              keyboardType={keyboardType}
-              secureTextEntry={type === 'password'}
-              style={{
-                ...essentialInputStyles.inputContainer,
-                width: clacWidth,
-                color: validation(value) ? colors.error : colors.grey,
-                borderColor: validation(value) ? colors.error : colors.grey,
-              }}
-              onChangeText={(textValue: string) =>
-                handleChangeText(textValue, setValue)
-              }
-              {...rest}
-            />
-            <View style={essentialInputStyles.validateStatus}>
-              {validation(value) &&
-                value.length > 0 &&
-                type !== 'authnumber' && (
-                  <Text variant="body1" color="error">
-                    !
-                  </Text>
-                )}
-              {!validation(value) &&
-                value.length > 0 &&
-                type !== 'authnumber' && (
-                  <Icon name="IconCheck" size={20} fill="green" />
-                )}
-            </View>
+      <Text color="grey" style={essentialInputStyles.label}>
+        {label}
+      </Text>
+
+      <View style={essentialInputStyles.phoneInputRow}>
+        <View style={essentialInputStyles.inputAbsoluteContainer}>
+          <TextInput
+            value={value}
+            maxLength={maxLength}
+            keyboardType={keyboardType}
+            secureTextEntry={type === 'password'}
+            style={{
+              ...essentialInputStyles.inputContainer,
+              color: validation(value) ? colors.error : colors.white,
+              borderColor: validation(value) ? colors.error : colors.darkGrey,
+            }}
+            onChangeText={(textValue: string) =>
+              handleChangeText(textValue, setValue)
+            }
+            {...rest}
+          />
+
+          <View style={essentialInputStyles.helpTextContainer}>
+            <ErrorText validation={validation} value={value} />
           </View>
-          {children}
+
+          <View style={essentialInputStyles.validateStatus}>
+            {validation(value) && value.length > 0 && type !== 'authnumber' && (
+              <Text variant="body1" color="error">
+                !
+              </Text>
+            )}
+            {!validation(value) &&
+              value.length > 0 &&
+              type !== 'authnumber' && (
+                <Icon name="IconCheck" size={20} fill="green" />
+              )}
+          </View>
         </View>
-        <View style={{ width: clacWidth }}>
-          <ErrorText validation={validation} value={value} />
-        </View>
+        {children}
       </View>
+
+      <Spacing height={5} />
     </View>
   );
 };

--- a/src/components/authorize/inputs/GenderInput/GenderInput.style.ts
+++ b/src/components/authorize/inputs/GenderInput/GenderInput.style.ts
@@ -1,27 +1,18 @@
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { fonts } from 'styles/theme';
 
 const genderInputStyles = StyleSheet.create({
   container: {
     marginLeft: 7,
-    flexDirection: 'column',
-    ...Platform.select({
-      ios: {
-        marginTop: -5,
-      },
-    }),
+    justifyContent: 'space-between',
   },
   title: {
     marginBottom: 14,
-    color: 'white',
     fontSize: 18,
     fontFamily: fonts.semibold,
   },
   genderButtonContainer: {
     flexDirection: 'row',
-  },
-  errorText: {
-    color: 'red',
   },
 });
 

--- a/src/components/authorize/inputs/GenderInput/GenderInput.tsx
+++ b/src/components/authorize/inputs/GenderInput/GenderInput.tsx
@@ -31,12 +31,10 @@ const GenderInput = ({ value, setValue }: Props) => {
   };
   return (
     <View style={genderInputStyles.container}>
-      <Text variant="h4" color="white" style={genderInputStyles.title}>
-        성별
-      </Text>
+      <Text style={genderInputStyles.title}>성별</Text>
       <View style={genderInputStyles.genderButtonContainer}>
         <ColorButton
-          label="남"
+          label="남성"
           color={computedGenderAction(GenderType.MAN).color}
           marginRight={10}
           borderColor={computedGenderAction(GenderType.MAN).borderColor}
@@ -44,7 +42,7 @@ const GenderInput = ({ value, setValue }: Props) => {
           handleClick={computedGenderAction(GenderType.MAN).handlePress}
         />
         <ColorButton
-          label="여"
+          label="여성"
           color={computedGenderAction(GenderType.WOMAN).color}
           marginRight={10}
           borderColor={computedGenderAction(GenderType.WOMAN).borderColor}

--- a/src/components/authorize/inputs/GenderInput/GenderInput.tsx
+++ b/src/components/authorize/inputs/GenderInput/GenderInput.tsx
@@ -36,7 +36,7 @@ const GenderInput = ({ value, setValue }: Props) => {
       </Text>
       <View style={genderInputStyles.genderButtonContainer}>
         <ColorButton
-          label={GenderType.MAN}
+          label="남"
           color={computedGenderAction(GenderType.MAN).color}
           marginRight={10}
           borderColor={computedGenderAction(GenderType.MAN).borderColor}
@@ -44,7 +44,7 @@ const GenderInput = ({ value, setValue }: Props) => {
           handleClick={computedGenderAction(GenderType.MAN).handlePress}
         />
         <ColorButton
-          label={GenderType.WOMAN}
+          label="여"
           color={computedGenderAction(GenderType.WOMAN).color}
           marginRight={10}
           borderColor={computedGenderAction(GenderType.WOMAN).borderColor}

--- a/src/components/authorize/inputs/LoginInput/LoginInput.style.ts
+++ b/src/components/authorize/inputs/LoginInput/LoginInput.style.ts
@@ -1,21 +1,15 @@
-import { Dimensions, Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import textStyles from 'styles/textStyles';
 
 const loginInputStyles = StyleSheet.create({
-  container: {
-    margin: Platform.OS === 'android' ? 7 : 15,
-    flexDirection: 'column',
-  },
   input: {
-    width: Dimensions.get('window').width - 60,
     paddingVertical: 10,
     borderBottomWidth: 1,
     backgroundColor: 'transparent',
     ...textStyles.body2,
   },
   inputTitle: {
-    color: 'white',
-    marginBottom: Platform.OS === 'android' ? 2 : 20,
+    marginBottom: 10,
   },
   validateStatus: {
     position: 'absolute',

--- a/src/components/authorize/inputs/LoginInput/LoginInput.tsx
+++ b/src/components/authorize/inputs/LoginInput/LoginInput.tsx
@@ -16,7 +16,7 @@ const LoginInput = ({ label, value, setValue, type, validation }: Props) => {
   const PASSWORD = '비밀번호를';
   const EMAIL = '이메일을';
   return (
-    <View style={loginInputStyles.container}>
+    <View>
       <Text variant="h4" style={loginInputStyles.inputTitle}>
         {label}
       </Text>

--- a/src/components/authorize/texts/ErrorText/ErrorText.style.ts
+++ b/src/components/authorize/texts/ErrorText/ErrorText.style.ts
@@ -1,10 +1,11 @@
 import { StyleSheet } from 'react-native';
-import { colors } from 'styles/theme';
 
 const errorTextStyles = StyleSheet.create({
   text: {
     height: 20,
-    width: '100%',
+    flex: 1,
+    textAlign: 'right',
+    alignSelf: 'flex-end',
   },
 });
 

--- a/src/components/authorize/texts/ErrorText/ErrorText.tsx
+++ b/src/components/authorize/texts/ErrorText/ErrorText.tsx
@@ -11,8 +11,8 @@ interface Props {
 const ErrorText = ({ validation, value, width = 350 }: Props) => {
   const calcFontSize = () => {
     const validate = validation(value);
-    if (!validate) return 12;
-    return validate.length > 29 ? 10 : 12;
+    if (!validate) return 11;
+    return validate.length > 20 ? 10 : 11;
   };
   return (
     <View>
@@ -24,7 +24,7 @@ const ErrorText = ({ validation, value, width = 350 }: Props) => {
           style={{
             ...errorTextStyles.text,
             width,
-            fontSize: Platform.OS === 'android' ? 12 : calcFontSize(),
+            fontSize: Platform.OS === 'android' ? 11 : calcFontSize(),
           }}
         >
           {validation(value)}

--- a/src/components/authorize/texts/TimerText/TimerText.style.ts
+++ b/src/components/authorize/texts/TimerText/TimerText.style.ts
@@ -1,9 +1,13 @@
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
+import { getPixelSize } from 'styles/styleUtils';
 
 const timerTextStyles = StyleSheet.create({
   textContainer: {
     position: 'absolute',
-    top: 17,
+    top: Platform.select({
+      android: getPixelSize(34),
+      ios: 17,
+    }),
     right: 16,
     zIndex: 7,
   },

--- a/src/components/authorize/texts/TimerText/TimerText.style.ts
+++ b/src/components/authorize/texts/TimerText/TimerText.style.ts
@@ -1,10 +1,10 @@
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 const timerTextStyles = StyleSheet.create({
   textContainer: {
     position: 'absolute',
-    top: Platform.OS === 'android' ? 18 : 12,
-    right: 5,
+    top: 17,
+    right: 16,
     zIndex: 7,
   },
 });

--- a/src/components/authorize/texts/TimerText/TimerText.tsx
+++ b/src/components/authorize/texts/TimerText/TimerText.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const TimerText = memo(({ setTimerTrigger, timerTrigger, setRetry }: Props) => {
-  const MINUTES_IN_MS = 3 * 60 * 1000;
+  const MINUTES_IN_MS = 5 * 60 * 1000;
   const INTERVAL = 1000;
   const [timeLeft, setTimeLeft] = useState<number>(MINUTES_IN_MS);
   const [currentReactive, setCurrentReactive] = useState<boolean>(

--- a/src/components/common/dialogs/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/common/dialogs/ConfirmDialog/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import Text from 'components/common/Text/Text';
-import { Modal, Pressable, TouchableOpacity, View } from 'react-native';
+import { Pressable, TouchableOpacity, View } from 'react-native';
 import { ConfirmDialog as ConfirmDialogType } from 'types/apps/dialog';
+import { Modal } from 'react-native-paper';
 import confirmDialogStyles from './ConfirmDialog.style';
 
 interface Props {
@@ -14,12 +15,7 @@ const ConfirmDialog = ({ dialog, closeDialog }: Props) => {
     closeDialog();
   };
   return (
-    <Modal
-      animationType="fade"
-      transparent
-      visible={dialog.isShow}
-      style={confirmDialogStyles.modalView}
-    >
+    <Modal visible={dialog.isShow} style={confirmDialogStyles.modalView}>
       <Pressable
         onPress={(event) => {
           event.stopPropagation();

--- a/src/components/common/dialogs/Dialog/Dialog.tsx
+++ b/src/components/common/dialogs/Dialog/Dialog.tsx
@@ -1,5 +1,6 @@
-import { Modal, Pressable, TouchableOpacity, View } from 'react-native';
+import { Pressable, TouchableOpacity, View } from 'react-native';
 import { CommonDialog } from 'types/apps/dialog';
+import { Modal } from 'react-native-paper';
 import Icon from '../../Icon/Icon';
 import Text from '../../Text/Text';
 import dialogStyles from './Dialog.style';
@@ -11,12 +12,7 @@ interface Props {
 
 const Dialog = ({ dialog, closeDialog }: Props) => {
   return (
-    <Modal
-      animationType="fade"
-      transparent
-      visible={dialog.isShow}
-      style={dialogStyles.modalView}
-    >
+    <Modal visible={dialog.isShow} style={dialogStyles.modalView}>
       <Pressable
         onPress={(event) => {
           event.stopPropagation();

--- a/src/components/common/dialogs/DialogProvider.tsx
+++ b/src/components/common/dialogs/DialogProvider.tsx
@@ -1,6 +1,7 @@
 import useDialog from 'hooks/app/useDialog';
 import { PropsWithChildren } from 'react';
 import DialogContext from 'utils/DialogContext';
+import { Provider, Portal } from 'react-native-paper';
 import ConfirmDialog from './ConfirmDialog/ConfirmDialog';
 import Dialog from './Dialog/Dialog';
 
@@ -10,12 +11,16 @@ const DialogProvider = ({ children }: PropsWithChildren) => {
 
   return (
     <DialogContext.Provider value={dialogContextValue}>
-      <Dialog dialog={dialog} closeDialog={() => closeDialog('success')} />
-      <ConfirmDialog
-        dialog={confirmDialog}
-        closeDialog={() => closeDialog('confirm')}
-      />
-      {children}
+      <Provider>
+        <Portal>
+          <Dialog dialog={dialog} closeDialog={() => closeDialog('success')} />
+          <ConfirmDialog
+            dialog={confirmDialog}
+            closeDialog={() => closeDialog('confirm')}
+          />
+        </Portal>
+        {children}
+      </Provider>
     </DialogContext.Provider>
   );
 };

--- a/src/components/common/dialogs/DialogProvider.tsx
+++ b/src/components/common/dialogs/DialogProvider.tsx
@@ -1,6 +1,5 @@
 import useDialog from 'hooks/app/useDialog';
 import { PropsWithChildren } from 'react';
-import { Portal } from 'react-native-paper';
 import DialogContext from 'utils/DialogContext';
 import ConfirmDialog from './ConfirmDialog/ConfirmDialog';
 import Dialog from './Dialog/Dialog';
@@ -10,18 +9,14 @@ const DialogProvider = ({ children }: PropsWithChildren) => {
     useDialog();
 
   return (
-    <Portal.Host>
-      <DialogContext.Provider value={dialogContextValue}>
-        {children}
-        <Portal>
-          <Dialog dialog={dialog} closeDialog={() => closeDialog('success')} />
-          <ConfirmDialog
-            dialog={confirmDialog}
-            closeDialog={() => closeDialog('confirm')}
-          />
-        </Portal>
-      </DialogContext.Provider>
-    </Portal.Host>
+    <DialogContext.Provider value={dialogContextValue}>
+      <Dialog dialog={dialog} closeDialog={() => closeDialog('success')} />
+      <ConfirmDialog
+        dialog={confirmDialog}
+        closeDialog={() => closeDialog('confirm')}
+      />
+      {children}
+    </DialogContext.Provider>
   );
 };
 

--- a/src/constants/join.ts
+++ b/src/constants/join.ts
@@ -11,8 +11,8 @@ const enum UserInfoStatus {
 }
 
 const enum GenderType {
-  MAN = '남',
-  WOMAN = '여',
+  MAN = 'MAN',
+  WOMAN = 'WOMAN',
 }
 
 export { GenderType, UserInfoStatus };

--- a/src/hooks/app/useDialog.tsx
+++ b/src/hooks/app/useDialog.tsx
@@ -71,7 +71,7 @@ const useDialog = () => {
       case 'validate':
         dialog.callback();
         return setDialog({
-          type: 'success',
+          ...dialog,
           text: '',
           isShow: false,
           contents: '',

--- a/src/hooks/authorize/usePhoneCertificate.ts
+++ b/src/hooks/authorize/usePhoneCertificate.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { validateAuthNumber, validatePhoneNumber } from 'utils/validate';
+
+const usePhoneCertificate = () => {
+  const [authnumber, setAuthnumber] = useState<string>('');
+  const [phonenumber, setPhonenumber] = useState<string>('');
+  const [retry, setRetry] = useState<boolean>(false);
+  const isActive =
+    !validatePhoneNumber(phonenumber) &&
+    phonenumber.length > 1 &&
+    !validateAuthNumber(authnumber) &&
+    authnumber.length > 1 &&
+    retry;
+  return {
+    isActive,
+    authnumber,
+    setAuthnumber,
+    phonenumber,
+    setPhonenumber,
+    retry,
+    setRetry,
+  };
+};
+
+export default usePhoneCertificate;

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { applyToken } from 'apis';
 import { checkEmail, normalLogin, normalSignUp, socialLogin } from 'apis/auth';
+import { getMyInfo } from 'apis/user';
 import { NormalSignInRequestDto } from 'models/auth/request/NormalSignInRequestDto';
 import { SocialSignupRequestDto } from 'models/auth/request/SocialSignupRequestDto';
 import { useAuthorizeStore } from 'stores/Authorize';
@@ -12,22 +13,44 @@ export const useNormalLogin = (
   successCallback?: () => void,
   errorCallback?: (error: ApiErrorResponse) => void,
 ) => {
-  return useMutation((data: NormalSignInRequestDto) => normalLogin(data), {
-    onSuccess: successCallback,
-    onError: errorCallback,
-    useErrorBoundary: false,
-  });
+  return useMutation(
+    (data: NormalSignInRequestDto) =>
+      normalLogin(data).then((socialToken) => {
+        setToken({
+          accessToken: socialToken.data?.accessToken,
+          refreshToken: socialToken.data?.refreshToken,
+        });
+        applyToken(socialToken.data?.accessToken ?? '');
+        return getMyInfo();
+      }),
+    {
+      onSuccess: successCallback,
+      onError: errorCallback,
+      useErrorBoundary: false,
+    },
+  );
 };
 
 export const useSocialLogin = (
   successCallback?: () => void,
   errorCallback?: (error: ApiErrorResponse) => void,
 ) => {
-  return useMutation((data: SocialSignupRequestDto) => socialLogin(data), {
-    onSuccess: successCallback,
-    onError: errorCallback,
-    useErrorBoundary: false,
-  });
+  return useMutation(
+    (data: SocialSignupRequestDto) =>
+      socialLogin(data).then((socialToken) => {
+        setToken({
+          accessToken: socialToken.data?.accessToken,
+          refreshToken: socialToken.data?.refreshToken,
+        });
+        applyToken(socialToken.data?.accessToken ?? '');
+        return getMyInfo();
+      }),
+    {
+      onSuccess: successCallback,
+      onError: errorCallback,
+      useErrorBoundary: false,
+    },
+  );
 };
 
 export const useEmailCheck = (

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -1,15 +1,57 @@
-import { ApiErrorResponse } from 'types/ApiResponse';
 import { useMutation } from '@tanstack/react-query';
-import { normalLogin } from 'apis/auth';
+import { applyToken } from 'apis';
+import { checkEmail, normalLogin, normalSignUp, socialLogin } from 'apis/auth';
 import { NormalSignInRequestDto } from 'models/auth/request/NormalSignInRequestDto';
+import { SocialSignupRequestDto } from 'models/auth/request/SocialSignupRequestDto';
+import { useAuthorizeStore } from 'stores/Authorize';
+import { ApiErrorResponse } from 'types/ApiResponse';
 
-// eslint-disable-next-line import/prefer-default-export
+const { setToken } = useAuthorizeStore.getState();
+
 export const useNormalLogin = (
   successCallback?: () => void,
   errorCallback?: (error: ApiErrorResponse) => void,
 ) => {
   return useMutation((data: NormalSignInRequestDto) => normalLogin(data), {
     onSuccess: successCallback,
+    onError: errorCallback,
+    useErrorBoundary: false,
+  });
+};
+
+export const useSocialLogin = (
+  successCallback?: () => void,
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation((data: SocialSignupRequestDto) => socialLogin(data), {
+    onSuccess: successCallback,
+    onError: errorCallback,
+    useErrorBoundary: false,
+  });
+};
+
+export const useEmailCheck = (
+  successCallback?: () => void,
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation((email: string) => checkEmail(email), {
+    onSuccess: successCallback,
+    onError: errorCallback,
+    useErrorBoundary: false,
+  });
+};
+
+export const useNormalSignUp = (
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation((data: NormalSignInRequestDto) => normalSignUp(data), {
+    onSuccess: (data) => {
+      applyToken(data.data?.accessToken ?? '');
+      setToken({
+        accessToken: data.data?.accessToken,
+        refreshToken: data.data?.refreshToken,
+      });
+    },
     onError: errorCallback,
     useErrorBoundary: false,
   });

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -1,15 +1,22 @@
 import { useMutation } from '@tanstack/react-query';
 import { applyToken } from 'apis';
 import {
+  checkAuthSms,
   checkEmail,
   checkNickname,
   normalLogin,
   normalSignUp,
+  resetPassword,
+  searchEmail,
+  sendAuthSms,
   socialLogin,
 } from 'apis/auth';
 import { getMyInfo } from 'apis/user';
 import { NormalSignInRequestDto } from 'models/auth/request/NormalSignInRequestDto';
+import ResetPasswordRequestDto from 'models/auth/request/ResetPasswordRequestDto';
 import { SocialSignupRequestDto } from 'models/auth/request/SocialSignupRequestDto';
+import NCPSmsInfoRequestDto from 'models/user/request/NCPSmsInfoRequestDto';
+import UserSmsCheckRequestDto from 'models/user/request/UserSmsCheckRequestDto';
 import { useAuthorizeStore } from 'stores/Authorize';
 import { ApiErrorResponse } from 'types/ApiResponse';
 
@@ -93,5 +100,45 @@ export const useNicknameCheck = (
 ) => {
   return useMutation((nickname: string) => checkNickname(nickname), {
     onError: errorCallback,
+  });
+};
+
+export const useSendAuthSms = (
+  successCallback?: () => void,
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation((data: NCPSmsInfoRequestDto) => sendAuthSms(data), {
+    onSuccess: successCallback,
+    onError: errorCallback,
+    useErrorBoundary: false,
+  });
+};
+
+export const useCheckAuthSms = (
+  successCallback?: () => void,
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation(
+    async (data: UserSmsCheckRequestDto) => {
+      await checkAuthSms(data);
+      const emailInfo = await searchEmail(data.phoneNum);
+      return emailInfo;
+    },
+    {
+      onSuccess: successCallback,
+      onError: errorCallback,
+      useErrorBoundary: false,
+    },
+  );
+};
+
+export const useResetPassword = (
+  successCallback?: () => void,
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation((data: ResetPasswordRequestDto) => resetPassword(data), {
+    onSuccess: successCallback,
+    onError: errorCallback,
+    useErrorBoundary: false,
   });
 };

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -1,6 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
 import { applyToken } from 'apis';
-import { checkEmail, normalLogin, normalSignUp, socialLogin } from 'apis/auth';
+import {
+  checkEmail,
+  checkNickname,
+  normalLogin,
+  normalSignUp,
+  socialLogin,
+} from 'apis/auth';
 import { getMyInfo } from 'apis/user';
 import { NormalSignInRequestDto } from 'models/auth/request/NormalSignInRequestDto';
 import { SocialSignupRequestDto } from 'models/auth/request/SocialSignupRequestDto';
@@ -14,15 +20,16 @@ export const useNormalLogin = (
   errorCallback?: (error: ApiErrorResponse) => void,
 ) => {
   return useMutation(
-    (data: NormalSignInRequestDto) =>
-      normalLogin(data).then((socialToken) => {
-        setToken({
-          accessToken: socialToken.data?.accessToken,
-          refreshToken: socialToken.data?.refreshToken,
-        });
-        applyToken(socialToken.data?.accessToken ?? '');
-        return getMyInfo();
-      }),
+    async (data: NormalSignInRequestDto) => {
+      const normalToken = await normalLogin(data);
+      setToken({
+        accessToken: normalToken.data?.accessToken,
+        refreshToken: normalToken.data?.refreshToken,
+      });
+      applyToken(normalToken.data?.accessToken ?? '');
+      const myInfo = await getMyInfo();
+      return myInfo;
+    },
     {
       onSuccess: successCallback,
       onError: errorCallback,
@@ -36,15 +43,16 @@ export const useSocialLogin = (
   errorCallback?: (error: ApiErrorResponse) => void,
 ) => {
   return useMutation(
-    (data: SocialSignupRequestDto) =>
-      socialLogin(data).then((socialToken) => {
-        setToken({
-          accessToken: socialToken.data?.accessToken,
-          refreshToken: socialToken.data?.refreshToken,
-        });
-        applyToken(socialToken.data?.accessToken ?? '');
-        return getMyInfo();
-      }),
+    async (data: SocialSignupRequestDto) => {
+      const normalToken = await socialLogin(data);
+      setToken({
+        accessToken: normalToken.data?.accessToken,
+        refreshToken: normalToken.data?.refreshToken,
+      });
+      applyToken(normalToken.data?.accessToken ?? '');
+      const myInfo = await getMyInfo();
+      return myInfo;
+    },
     {
       onSuccess: successCallback,
       onError: errorCallback,
@@ -77,5 +85,13 @@ export const useNormalSignUp = (
     },
     onError: errorCallback,
     useErrorBoundary: false,
+  });
+};
+
+export const useNicknameCheck = (
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation((nickname: string) => checkNickname(nickname), {
+    onError: errorCallback,
   });
 };

--- a/src/hooks/queries/user.ts
+++ b/src/hooks/queries/user.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { updateInterestField } from 'apis/field';
+import { updateInterestField } from 'apis/interest';
 import { checkSms, sendSms, updateOnBoarding } from 'apis/user';
 import AddInterestRequestDto from 'models/field/request/AddInterestRequestDto';
 import NCPSmsInfoRequestDto from 'models/user/request/NCPSmsInfoRequestDto';
@@ -36,10 +36,11 @@ interface ConcludeOnBoardingProps {
 
 export const useConcludeOnBoarding = () => {
   return useMutation(
-    (data: ConcludeOnBoardingProps) =>
-      updateInterestField(data.fields).then(() => {
-        updateOnBoarding(data.onBoarding);
-      }),
+    async (data: ConcludeOnBoardingProps) => {
+      await updateInterestField(data.fields);
+      const onboarding = await updateOnBoarding(data.onBoarding);
+      return onboarding;
+    },
     {
       useErrorBoundary: false,
     },

--- a/src/hooks/queries/user.ts
+++ b/src/hooks/queries/user.ts
@@ -37,8 +37,8 @@ interface ConcludeOnBoardingProps {
 export const useConcludeOnBoarding = () => {
   return useMutation(
     (data: ConcludeOnBoardingProps) =>
-      updateOnBoarding(data.onBoarding).then(() => {
-        updateInterestField(data.fields);
+      updateInterestField(data.fields).then(() => {
+        updateOnBoarding(data.onBoarding);
       }),
     {
       useErrorBoundary: false,

--- a/src/hooks/queries/user.ts
+++ b/src/hooks/queries/user.ts
@@ -1,0 +1,47 @@
+import { useMutation } from '@tanstack/react-query';
+import { updateInterestField } from 'apis/field';
+import { checkSms, sendSms, updateOnBoarding } from 'apis/user';
+import AddInterestRequestDto from 'models/field/request/AddInterestRequestDto';
+import NCPSmsInfoRequestDto from 'models/user/request/NCPSmsInfoRequestDto';
+import UserOnboardingRequestDto from 'models/user/request/UserOnboardingRequestDto';
+import UserSmsCheckRequestDto from 'models/user/request/UserSmsCheckRequestDto';
+import { ApiErrorResponse } from 'types/ApiResponse';
+
+export const useSendSms = (
+  successCallback?: () => void,
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation((data: NCPSmsInfoRequestDto) => sendSms(data), {
+    onSuccess: successCallback,
+    onError: errorCallback,
+    useErrorBoundary: false,
+  });
+};
+
+export const useCheckSms = (
+  successCallback?: () => void,
+  errorCallback?: (error: ApiErrorResponse) => void,
+) => {
+  return useMutation((data: UserSmsCheckRequestDto) => checkSms(data), {
+    onSuccess: successCallback,
+    onError: errorCallback,
+    useErrorBoundary: false,
+  });
+};
+
+interface ConcludeOnBoardingProps {
+  onBoarding: UserOnboardingRequestDto;
+  fields: AddInterestRequestDto;
+}
+
+export const useConcludeOnBoarding = () => {
+  return useMutation(
+    (data: ConcludeOnBoardingProps) =>
+      updateOnBoarding(data.onBoarding).then(() => {
+        updateInterestField(data.fields);
+      }),
+    {
+      useErrorBoundary: false,
+    },
+  );
+};

--- a/src/models/auth/request/ResetPasswordRequestDto.ts
+++ b/src/models/auth/request/ResetPasswordRequestDto.ts
@@ -1,0 +1,7 @@
+interface ResetPasswordRequestDto {
+  email: string;
+  phoneNum: string;
+  newPassword: string;
+}
+
+export default ResetPasswordRequestDto;

--- a/src/models/auth/request/SocialSignupRequestDto.ts
+++ b/src/models/auth/request/SocialSignupRequestDto.ts
@@ -1,0 +1,4 @@
+export interface SocialSignupRequestDto {
+  socialType: 'google' | 'kakao' | 'apple';
+  token: string;
+}

--- a/src/models/auth/request/TokenRequestDto.ts
+++ b/src/models/auth/request/TokenRequestDto.ts
@@ -1,0 +1,4 @@
+export interface TokenRequestDto {
+  accessToken: string | undefined;
+  refreshToken: string | undefined;
+}

--- a/src/models/auth/response/CheckEmailResponseDto.ts
+++ b/src/models/auth/response/CheckEmailResponseDto.ts
@@ -1,0 +1,3 @@
+export interface CheckEmailResponseDto {
+  check: boolean;
+}

--- a/src/models/auth/response/CheckNicknameResponseDto.ts
+++ b/src/models/auth/response/CheckNicknameResponseDto.ts
@@ -1,0 +1,3 @@
+export interface CheckNicknameResponseDto {
+  isExist: boolean;
+}

--- a/src/models/auth/response/SearchIdResponseDto.ts
+++ b/src/models/auth/response/SearchIdResponseDto.ts
@@ -1,0 +1,5 @@
+interface SearchIdResponseDto {
+  id: string;
+}
+
+export default SearchIdResponseDto;

--- a/src/models/field/request/AddInterestRequestDto.ts
+++ b/src/models/field/request/AddInterestRequestDto.ts
@@ -1,0 +1,7 @@
+import { FieldCode } from 'constants/code';
+
+interface AddInterestRequestDto {
+  fieldTypeList: FieldCode[];
+}
+
+export default AddInterestRequestDto;

--- a/src/models/user/request/NCPSmsInfoRequestDto.ts
+++ b/src/models/user/request/NCPSmsInfoRequestDto.ts
@@ -1,0 +1,6 @@
+interface NCPSmsInfoRequestDto {
+  to: string;
+  content: string;
+}
+
+export default NCPSmsInfoRequestDto;

--- a/src/models/user/request/UserOnboardingRequestDto.ts
+++ b/src/models/user/request/UserOnboardingRequestDto.ts
@@ -1,0 +1,12 @@
+import { Gender } from 'types/join';
+
+interface UserOnboardingRequestDto {
+  nickname: string;
+  username: string;
+  gender: Gender;
+  year: number;
+  month: number;
+  day: number;
+}
+
+export default UserOnboardingRequestDto;

--- a/src/models/user/request/UserSmsCheckRequestDto.ts
+++ b/src/models/user/request/UserSmsCheckRequestDto.ts
@@ -1,0 +1,6 @@
+interface UserSmsCheckRequestDto {
+  phoneNum: string;
+  checkNum: string;
+}
+
+export default UserSmsCheckRequestDto;

--- a/src/models/user/response/UserTotalInfoResponseDto.ts
+++ b/src/models/user/response/UserTotalInfoResponseDto.ts
@@ -1,0 +1,23 @@
+import { FieldCode } from 'constants/code';
+import SocialAccountInfo from 'types/user';
+
+interface UserTotalInfoResponseDto {
+  userInfo: {
+    uuid: string;
+    userName: string;
+    nickName: string;
+    profileImageUrl: string;
+    birth: {
+      year: number;
+      month: number;
+      day: number;
+      isAdult: boolean;
+    };
+    gender: 'MAN' | 'WOMAN';
+    phoneNumber: string;
+    fieldTypeList: FieldCode[];
+  };
+  socialAccountInfoList: SocialAccountInfo[];
+}
+
+export default UserTotalInfoResponseDto;

--- a/src/navigators/AuthorizeNavigator.tsx
+++ b/src/navigators/AuthorizeNavigator.tsx
@@ -4,7 +4,7 @@ import {
 } from '@react-navigation/stack';
 import BackToHomeButton from 'components/authorize/buttons/BackToHomeButton/BackToHomeButton';
 import BackButton from 'components/navigator/BackButton';
-import { UserInfoStatus } from 'constants/join';
+import { GenderType, UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
 import React, { Reducer, useReducer } from 'react';
 import { Platform } from 'react-native';
@@ -30,7 +30,7 @@ interface Props {
 const userInfoReducer = (state: JoinInfo, action: Action): JoinInfo => {
   switch (action.type) {
     case UserInfoStatus.SET_NAME:
-      return { ...state, name: action.name };
+      return { ...state, username: action.username };
     case UserInfoStatus.SET_BIRTH:
       return { ...state, birth: action.birth };
     case UserInfoStatus.SET_AGREE_TO_TERM:
@@ -56,12 +56,12 @@ const userInfoReducer = (state: JoinInfo, action: Action): JoinInfo => {
 
 const AuthorizeNavigator = () => {
   const initialState = {
-    name: '',
+    username: '',
     birth: '',
     agreeToTerm: '',
     phoneNumber: '',
     nickname: '',
-    gender: '',
+    gender: GenderType.MAN,
     emailAddress: '',
     password: '',
     interestField: [],
@@ -158,7 +158,7 @@ const AuthorizeNavigator = () => {
         }}
         name={AuthorizeMenu.InterestField}
       >
-        {() => <InterestFieldScreen dispatch={dispatch} />}
+        {() => <InterestFieldScreen state={state} dispatch={dispatch} />}
       </Stack.Screen>
       <Stack.Screen
         options={{

--- a/src/navigators/AuthorizeNavigator.tsx
+++ b/src/navigators/AuthorizeNavigator.tsx
@@ -118,7 +118,7 @@ const AuthorizeNavigator = () => {
       <Stack.Screen
         options={{
           headerTitle: '',
-          headerLeft: BackButton,
+          headerLeft: () => null,
         }}
         name={AuthorizeMenu.AgreeToTerm}
       >

--- a/src/navigators/AuthorizeNavigator.tsx
+++ b/src/navigators/AuthorizeNavigator.tsx
@@ -54,7 +54,7 @@ const userInfoReducer = (state: JoinInfo, action: Action): JoinInfo => {
   }
 };
 
-const AuthorizeNavigator = ({ setIsLogin }: Props) => {
+const AuthorizeNavigator = () => {
   const initialState = {
     name: '',
     birth: '',
@@ -104,7 +104,7 @@ const AuthorizeNavigator = ({ setIsLogin }: Props) => {
         }}
         name={AuthorizeMenu.Login}
       >
-        {() => <LoginScreen setIsLogin={setIsLogin} />}
+        {() => <LoginScreen />}
       </Stack.Screen>
       <Stack.Screen
         options={{
@@ -164,11 +164,11 @@ const AuthorizeNavigator = ({ setIsLogin }: Props) => {
         options={{
           headerTitle: '',
           // eslint-disable-next-line react/no-unstable-nested-components
-          headerLeft: () => <BackToHomeButton setIsLogin={setIsLogin} />,
+          headerLeft: () => <BackToHomeButton />,
         }}
         name={AuthorizeMenu.JoinComplete}
       >
-        {() => <JoinCompleteScreen state={state} setIsLogin={setIsLogin} />}
+        {() => <JoinCompleteScreen state={state} />}
       </Stack.Screen>
       <Stack.Screen
         name={AuthorizeMenu.EmailPasswordFind}

--- a/src/screens/authorize/finds/EmailFindCompleteScreen/EmailFindCompleteScreen.tsx
+++ b/src/screens/authorize/finds/EmailFindCompleteScreen/EmailFindCompleteScreen.tsx
@@ -1,19 +1,38 @@
-import React from 'react';
-import { View, Image } from 'react-native';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
+import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import Text from 'components/common/Text/Text';
+import { AuthorizeMenu } from 'constants/menu';
+import { Image, View } from 'react-native';
+import { AuthStackParamList } from 'types/apps/menu';
 import emailFindCompleteScreenStyles from './EmailFindCompleteScreen.style';
 
-const EmailFindCompleteScreen = () => {
+interface Props {
+  email?: string;
+}
+
+const EmailFindCompleteScreen = ({ email }: Props) => {
+  const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
   return (
-    <View style={emailFindCompleteScreenStyles.authorizeContainer}>
-      <Image
-        style={emailFindCompleteScreenStyles.checkImage}
-        source={require('../../../../assets/images/check.png')}
-      />
-      <Text variant="h4" color="main">
-        아이디 찾기 결과입니다!
-      </Text>
-    </View>
+    <ScreenCover
+      authorizeButton={{
+        handlePress: () => navigation.navigate(AuthorizeMenu.Login),
+        label: '로그인 화면으로',
+        isActive: true,
+      }}
+    >
+      <View style={emailFindCompleteScreenStyles.authorizeContainer}>
+        <Image
+          style={emailFindCompleteScreenStyles.checkImage}
+          source={require('../../../../assets/images/check.png')}
+        />
+        <Text variant="h4" color="main">
+          아이디 찾기 결과입니다!
+        </Text>
+        <Text variant="h3" color="white">
+          {email}
+        </Text>
+      </View>
+    </ScreenCover>
   );
 };
 

--- a/src/screens/authorize/finds/EmailFindScreen/EmailFindScreen.tsx
+++ b/src/screens/authorize/finds/EmailFindScreen/EmailFindScreen.tsx
@@ -71,9 +71,8 @@ const EmailFindScreen = () => {
     setEmail(emailInfo.data?.id);
   };
 
-  if (isCheckAuthSms || isSendAuthSms) {
-    <CommonLoading isActive backgroundColor={colors.background} />;
-  }
+  if (isCheckAuthSms || isSendAuthSms)
+    return <CommonLoading isActive backgroundColor={colors.background} />;
 
   return (
     <View style={emailFindScreenStyles.container}>

--- a/src/screens/authorize/finds/EmailFindScreen/EmailFindScreen.tsx
+++ b/src/screens/authorize/finds/EmailFindScreen/EmailFindScreen.tsx
@@ -26,8 +26,7 @@ const EmailFindScreen = () => {
   const [isAuthorize, setIsAuthorize] = useState<boolean>(false);
 
   const handleCheckSmsError = (error: ApiErrorResponse) => {
-    const errorResponse = error.response;
-    if (errorResponse?.status === 404) {
+    if (error.response?.data.code === 800) {
       openDialog({
         type: 'validate',
         text: '해당 핸드폰으로 등록된 아이디가 존재하지 않습니다!',
@@ -72,7 +71,7 @@ const EmailFindScreen = () => {
     setEmail(emailInfo.data?.id);
   };
 
-  if (isCheckAuthSms && isSendAuthSms) {
+  if (isCheckAuthSms || isSendAuthSms) {
     <CommonLoading isActive backgroundColor={colors.background} />;
   }
 

--- a/src/screens/authorize/finds/EmailFindScreen/EmailFindScreen.tsx
+++ b/src/screens/authorize/finds/EmailFindScreen/EmailFindScreen.tsx
@@ -1,29 +1,81 @@
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import PhoneCertificationForm from 'components/authorize/forms/PhoneCertificationForm/PhoneCertificationForm';
-import Text from 'components/common/Text/Text';
-import { useState } from 'react';
-import { Image, View } from 'react-native';
-import { validateAuthNumber, validatePhoneNumber } from 'utils/validate';
-import emailFindScreenStyles from './EmailFindScreen.style';
+import CommonLoading from 'components/suspense/loading/CommonLoading/CommonLoading';
+import usePhoneCertificate from 'hooks/authorize/usePhoneCertificate';
+import { useCheckAuthSms, useSendAuthSms } from 'hooks/queries/auth';
+import { useContext, useState } from 'react';
+import { View } from 'react-native';
+import { colors } from 'styles/theme';
+import { ApiErrorResponse } from 'types/ApiResponse';
+import DialogContext from 'utils/DialogContext';
 import EmailFindCompleteScreen from '../EmailFindCompleteScreen/EmailFindCompleteScreen';
+import emailFindScreenStyles from './EmailFindScreen.style';
 
 const EmailFindScreen = () => {
-  const [phonenumber, setPhonenumber] = useState<string>('');
-  const [authnumber, setAuthnumber] = useState<string>('');
+  const { openDialog } = useContext(DialogContext);
+  const {
+    phonenumber,
+    setPhonenumber,
+    authnumber,
+    setAuthnumber,
+    retry,
+    setRetry,
+    isActive,
+  } = usePhoneCertificate();
+  const [email, setEmail] = useState<string | undefined>('');
   const [isAuthorize, setIsAuthorize] = useState<boolean>(false);
-  const [retry, setRetry] = useState<boolean>(false);
-  const handleCertification = () => {
-    setRetry(true);
+
+  const handleCheckSmsError = (error: ApiErrorResponse) => {
+    const errorResponse = error.response;
+    if (errorResponse?.status === 404) {
+      openDialog({
+        type: 'validate',
+        text: '해당 핸드폰으로 등록된 아이디가 존재하지 않습니다!',
+      });
+      return;
+    }
+    openDialog({
+      type: 'validate',
+      text: error.message,
+    });
   };
-  const handleAuthorizeFlow = () => {
+
+  const handleCheckSmsSuccess = () => {
     setIsAuthorize(true);
   };
-  const isActive =
-    !validatePhoneNumber(phonenumber) &&
-    phonenumber.length > 1 &&
-    !validateAuthNumber(authnumber) &&
-    authnumber.length > 1 &&
-    retry;
+
+  const handleSendSmsSuccess = () => {
+    openDialog({
+      type: 'success',
+      text: '인증번호를 발송하였습니다.',
+    });
+  };
+
+  const { mutateAsync: sendAuthSms, isLoading: isSendAuthSms } =
+    useSendAuthSms(handleSendSmsSuccess);
+  const { mutateAsync: checkAuthSms, isLoading: isCheckAuthSms } =
+    useCheckAuthSms(handleCheckSmsSuccess, handleCheckSmsError);
+
+  const handleCertification = async () => {
+    await sendAuthSms({
+      content: '일반 핸드폰 인증',
+      to: phonenumber.replaceAll('-', ''),
+    });
+    setRetry(true);
+  };
+
+  const handleAuthorizeFlow = async () => {
+    const emailInfo = await checkAuthSms({
+      phoneNum: phonenumber.replaceAll('-', ''),
+      checkNum: authnumber,
+    });
+    setEmail(emailInfo.data?.id);
+  };
+
+  if (isCheckAuthSms && isSendAuthSms) {
+    <CommonLoading isActive backgroundColor={colors.background} />;
+  }
+
   return (
     <View style={emailFindScreenStyles.container}>
       {!isAuthorize ? (
@@ -45,7 +97,7 @@ const EmailFindScreen = () => {
           />
         </ScreenCover>
       ) : (
-        <EmailFindCompleteScreen />
+        <EmailFindCompleteScreen email={email} />
       )}
     </View>
   );

--- a/src/screens/authorize/finds/EmailFindScreen/EmailFindScreen.tsx
+++ b/src/screens/authorize/finds/EmailFindScreen/EmailFindScreen.tsx
@@ -71,33 +71,35 @@ const EmailFindScreen = () => {
     setEmail(emailInfo.data?.id);
   };
 
-  if (isCheckAuthSms || isSendAuthSms)
-    return <CommonLoading isActive backgroundColor={colors.background} />;
-
   return (
-    <View style={emailFindScreenStyles.container}>
-      {!isAuthorize ? (
-        <ScreenCover
-          authorizeButton={{
-            handlePress: handleAuthorizeFlow,
-            label: '다음',
-            isActive,
-          }}
-        >
-          <PhoneCertificationForm
-            retry={retry}
-            phonenumber={phonenumber}
-            setPhonenumber={setPhonenumber}
-            authnumber={authnumber}
-            setAuthnumber={setAuthnumber}
-            handleCertification={handleCertification}
-            setRetry={setRetry}
-          />
-        </ScreenCover>
-      ) : (
-        <EmailFindCompleteScreen email={email} />
+    <>
+      {(isCheckAuthSms || isSendAuthSms) && (
+        <CommonLoading isActive backgroundColor={colors.background} />
       )}
-    </View>
+      <View style={emailFindScreenStyles.container}>
+        {!isAuthorize ? (
+          <ScreenCover
+            authorizeButton={{
+              handlePress: handleAuthorizeFlow,
+              label: '다음',
+              isActive,
+            }}
+          >
+            <PhoneCertificationForm
+              retry={retry}
+              phonenumber={phonenumber}
+              setPhonenumber={setPhonenumber}
+              authnumber={authnumber}
+              setAuthnumber={setAuthnumber}
+              handleCertification={handleCertification}
+              setRetry={setRetry}
+            />
+          </ScreenCover>
+        ) : (
+          <EmailFindCompleteScreen email={email} />
+        )}
+      </View>
+    </>
   );
 };
 

--- a/src/screens/authorize/finds/EmailPasswordFindScreen/EmailPasswordFindScreen.style.ts
+++ b/src/screens/authorize/finds/EmailPasswordFindScreen/EmailPasswordFindScreen.style.ts
@@ -1,32 +1,30 @@
-import { Dimensions, StyleSheet } from 'react-native';
+import { StyleSheet, TextStyle } from 'react-native';
+import { colors, fonts } from 'styles/theme';
 
 const emailPasswordFindScreenStyles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    flexDirection: 'column',
-  },
-  titleContainer: {
-    width: Dimensions.get('window').width,
-    alignItems: 'center',
   },
   findController: {
-    width: Dimensions.get('window').width,
     flexDirection: 'row',
   },
   button: {
-    flexDirection: 'column',
+    flex: 1,
+    borderBottomWidth: 5,
+    borderBottomColor: colors.background,
+  },
+  activeButton: {
+    borderBottomColor: colors.main,
   },
   buttonTextContainer: {
-    width: Dimensions.get('window').width / 2,
-    height: 41,
-    justifyContent: 'center',
+    paddingVertical: 10,
     alignItems: 'center',
   },
-  activeNotifier: {
-    width: Dimensions.get('window').width / 2,
-    height: 7,
-  },
+  tabText: {
+    fontFamily: fonts.semibold,
+    fontSize: 15,
+    lineHeight: 21,
+  } as TextStyle,
 });
 
 export default emailPasswordFindScreenStyles;

--- a/src/screens/authorize/finds/EmailPasswordFindScreen/EmailPasswordFindScreen.tsx
+++ b/src/screens/authorize/finds/EmailPasswordFindScreen/EmailPasswordFindScreen.tsx
@@ -2,7 +2,6 @@ import { NavigationProp, useNavigation } from '@react-navigation/native';
 import Text from 'components/common/Text/Text';
 import { useEffect, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import { colors } from 'styles/theme';
 import EmailFindScreen from '../EmailFindScreen/EmailFindScreen';
 import PasswordFindScreen from '../PasswordFindScreen/PasswordFindScreen';
 import emailPasswordFindScreenStyles from './EmailPasswordFindScreen.style';
@@ -25,36 +24,33 @@ const EmailPasswordFindScreen = () => {
     <View style={emailPasswordFindScreenStyles.container}>
       <View style={emailPasswordFindScreenStyles.findController}>
         <TouchableOpacity
-          style={emailPasswordFindScreenStyles.button}
+          activeOpacity={0.8}
+          style={[
+            emailPasswordFindScreenStyles.button,
+            screenMode === 'id' && emailPasswordFindScreenStyles.activeButton,
+          ]}
           onPress={() => setScreenMode('id')}
         >
           <View style={emailPasswordFindScreenStyles.buttonTextContainer}>
-            <Text>아이디</Text>
+            <Text style={emailPasswordFindScreenStyles.tabText}>아이디</Text>
           </View>
-          <View
-            style={{
-              ...emailPasswordFindScreenStyles.activeNotifier,
-              backgroundColor:
-                screenMode === 'id' ? colors.main : colors.background,
-            }}
-          />
         </TouchableOpacity>
+
         <TouchableOpacity
-          style={emailPasswordFindScreenStyles.button}
+          activeOpacity={0.8}
+          style={[
+            emailPasswordFindScreenStyles.button,
+            screenMode === 'password' &&
+              emailPasswordFindScreenStyles.activeButton,
+          ]}
           onPress={() => setScreenMode('password')}
         >
           <View style={emailPasswordFindScreenStyles.buttonTextContainer}>
-            <Text>비밀번호</Text>
+            <Text style={emailPasswordFindScreenStyles.tabText}>비밀번호</Text>
           </View>
-          <View
-            style={{
-              ...emailPasswordFindScreenStyles.activeNotifier,
-              backgroundColor:
-                screenMode === 'password' ? colors.main : colors.background,
-            }}
-          />
         </TouchableOpacity>
       </View>
+
       {screenMode === 'id' ? <EmailFindScreen /> : <PasswordFindScreen />}
     </View>
   );

--- a/src/screens/authorize/finds/EmailPasswordFindScreen/EmailPasswordFindScreen.tsx
+++ b/src/screens/authorize/finds/EmailPasswordFindScreen/EmailPasswordFindScreen.tsx
@@ -1,11 +1,11 @@
+import { NavigationProp, useNavigation } from '@react-navigation/native';
 import Text from 'components/common/Text/Text';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { colors } from 'styles/theme';
-import { NavigationProp, useNavigation } from '@react-navigation/native';
 import EmailFindScreen from '../EmailFindScreen/EmailFindScreen';
-import emailPasswordFindScreenStyles from './EmailPasswordFindScreen.style';
 import PasswordFindScreen from '../PasswordFindScreen/PasswordFindScreen';
+import emailPasswordFindScreenStyles from './EmailPasswordFindScreen.style';
 
 type ParamList = {
   passwordFind: undefined;
@@ -14,11 +14,13 @@ type ParamList = {
 const EmailPasswordFindScreen = () => {
   const navigation = useNavigation<NavigationProp<ParamList>>();
   const [screenMode, setScreenMode] = useState<'id' | 'password'>('id');
+
   useEffect(() => {
     navigation.setOptions({
       title: screenMode === 'id' ? '아이디 찾기' : '비밀번호 찾기',
     });
   }, [navigation, screenMode]);
+
   return (
     <View style={emailPasswordFindScreenStyles.container}>
       <View style={emailPasswordFindScreenStyles.findController}>

--- a/src/screens/authorize/finds/PasswordFindScreen/PasswordFindScreen.tsx
+++ b/src/screens/authorize/finds/PasswordFindScreen/PasswordFindScreen.tsx
@@ -1,59 +1,27 @@
-import PhoneAuthButton from 'components/authorize/buttons/PhoneAuthButton/PhoneAuthButton';
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
+import PhoneCertificationForm from 'components/authorize/forms/PhoneCertificationForm/PhoneCertificationForm';
 import EssentialInput from 'components/authorize/inputs/EssentialInput/EssentialInput';
-import TimerText from 'components/authorize/texts/TimerText/TimerText';
+import usePhoneCertificate from 'hooks/authorize/usePhoneCertificate';
 import { useState } from 'react';
 import { View } from 'react-native';
-import {
-  validateAuthNumber,
-  validateEmail,
-  validatePhoneNumber,
-} from 'utils/validate';
+import { validateEmail } from 'utils/validate';
 import PasswordResetScreen from '../PasswordResetScreen/PasswordResetScreen';
 import passwordFindScreenStyles from './PasswordFindScreen.style';
 
-interface Trigger {
-  active: boolean;
-  reactive: boolean;
-}
-
 const PasswordFindScreen = () => {
   const [emailAddress, setEmailAddress] = useState<string>('');
-  const [authnumber, setAuthnumber] = useState<string>('');
-  const [phonenumber, setPhonenumber] = useState<string>('');
+  const { phonenumber, setPhonenumber, authnumber, setAuthnumber, isActive } =
+    usePhoneCertificate();
   const [retry, setRetry] = useState<boolean>(false);
-  const [timerTrigger, setTimerTrigger] = useState<Trigger>({
-    active: false,
-    reactive: false,
-  });
   const [isAuthorize, setIsAuthorize] = useState<boolean>(false);
 
-  const isActive =
-    !validateEmail(emailAddress) &&
-    emailAddress.length > 1 &&
-    !validatePhoneNumber(phonenumber) &&
-    phonenumber.length > 1 &&
-    !validateAuthNumber(authnumber) &&
-    authnumber.length > 1 &&
-    retry;
+  const isResetButtonActive = isActive && retry;
 
   const handleCertification = () => {
     setRetry(true);
-    if (!timerTrigger.active) {
-      setTimerTrigger({ ...timerTrigger, active: true });
-      return;
-    }
-    setTimerTrigger({
-      ...timerTrigger,
-      reactive: !timerTrigger.reactive,
-    });
-    console.log(phonenumber);
   };
 
   const handleAuthorizeFlow = () => {
-    setTimerTrigger(() => {
-      return { reactive: false, active: false };
-    });
     setIsAuthorize(true);
   };
 
@@ -64,7 +32,7 @@ const PasswordFindScreen = () => {
           authorizeButton={{
             handlePress: handleAuthorizeFlow,
             label: '다음',
-            isActive,
+            isActive: isResetButtonActive,
           }}
         >
           <EssentialInput
@@ -75,38 +43,15 @@ const PasswordFindScreen = () => {
             setValue={setEmailAddress}
             type="emailAddress"
           />
-          <EssentialInput
-            validation={validatePhoneNumber}
-            label="휴대폰 번호"
-            keyboardType="number-pad"
-            value={phonenumber}
-            setValue={setPhonenumber}
-            type="phonenumber"
-          >
-            <PhoneAuthButton
-              label={retry ? '재발송' : '인증받기'}
-              active={
-                !(validatePhoneNumber(phonenumber) || phonenumber.length < 2)
-              }
-              handlePress={handleCertification}
-            />
-          </EssentialInput>
-          <EssentialInput
-            validation={validateAuthNumber}
-            label="인증번호"
-            keyboardType="number-pad"
-            value={authnumber}
-            setValue={setAuthnumber}
-            type="authnumber"
-          >
-            {timerTrigger.active && (
-              <TimerText
-                timerTrigger={timerTrigger}
-                setTimerTrigger={setTimerTrigger}
-                setRetry={setRetry}
-              />
-            )}
-          </EssentialInput>
+          <PhoneCertificationForm
+            retry={retry}
+            phonenumber={phonenumber}
+            setPhonenumber={setPhonenumber}
+            authnumber={authnumber}
+            setAuthnumber={setAuthnumber}
+            handleCertification={handleCertification}
+            setRetry={setRetry}
+          />
         </ScreenCover>
       ) : (
         <PasswordResetScreen />

--- a/src/screens/authorize/finds/PasswordFindScreen/PasswordFindScreen.tsx
+++ b/src/screens/authorize/finds/PasswordFindScreen/PasswordFindScreen.tsx
@@ -87,9 +87,8 @@ const PasswordFindScreen = () => {
     }
   };
 
-  if (isCheckAuthSms || isSendAuthSms) {
-    <CommonLoading isActive backgroundColor={colors.background} />;
-  }
+  if (isSendAuthSms || isCheckAuthSms)
+    return <CommonLoading isActive backgroundColor={colors.background} />;
 
   return (
     <View style={passwordFindScreenStyles.container}>

--- a/src/screens/authorize/finds/PasswordFindScreen/PasswordFindScreen.tsx
+++ b/src/screens/authorize/finds/PasswordFindScreen/PasswordFindScreen.tsx
@@ -120,7 +120,10 @@ const PasswordFindScreen = () => {
           />
         </ScreenCover>
       ) : (
-        <PasswordResetScreen email={emailAddress} />
+        <PasswordResetScreen
+          email={emailAddress}
+          phoneNum={phonenumber.replaceAll('-', '')}
+        />
       )}
     </View>
   );

--- a/src/screens/authorize/finds/PasswordFindScreen/PasswordFindScreen.tsx
+++ b/src/screens/authorize/finds/PasswordFindScreen/PasswordFindScreen.tsx
@@ -87,44 +87,46 @@ const PasswordFindScreen = () => {
     }
   };
 
-  if (isSendAuthSms || isCheckAuthSms)
-    return <CommonLoading isActive backgroundColor={colors.background} />;
-
   return (
-    <View style={passwordFindScreenStyles.container}>
-      {!isAuthorize ? (
-        <ScreenCover
-          authorizeButton={{
-            handlePress: handleAuthorizeFlow,
-            label: '다음',
-            isActive: isResetButtonActive,
-          }}
-        >
-          <EssentialInput
-            validation={validateEmail}
-            label="이메일"
-            keyboardType="default"
-            value={emailAddress}
-            setValue={setEmailAddress}
-            type="emailAddress"
-          />
-          <PhoneCertificationForm
-            retry={retry}
-            phonenumber={phonenumber}
-            setPhonenumber={setPhonenumber}
-            authnumber={authnumber}
-            setAuthnumber={setAuthnumber}
-            handleCertification={handleCertification}
-            setRetry={setRetry}
-          />
-        </ScreenCover>
-      ) : (
-        <PasswordResetScreen
-          email={emailAddress}
-          phoneNum={phonenumber.replaceAll('-', '')}
-        />
+    <>
+      {(isSendAuthSms || isCheckAuthSms) && (
+        <CommonLoading isActive backgroundColor={colors.background} />
       )}
-    </View>
+      <View style={passwordFindScreenStyles.container}>
+        {!isAuthorize ? (
+          <ScreenCover
+            authorizeButton={{
+              handlePress: handleAuthorizeFlow,
+              label: '다음',
+              isActive: isResetButtonActive,
+            }}
+          >
+            <EssentialInput
+              validation={validateEmail}
+              label="이메일"
+              keyboardType="default"
+              value={emailAddress}
+              setValue={setEmailAddress}
+              type="emailAddress"
+            />
+            <PhoneCertificationForm
+              retry={retry}
+              phonenumber={phonenumber}
+              setPhonenumber={setPhonenumber}
+              authnumber={authnumber}
+              setAuthnumber={setAuthnumber}
+              handleCertification={handleCertification}
+              setRetry={setRetry}
+            />
+          </ScreenCover>
+        ) : (
+          <PasswordResetScreen
+            email={emailAddress}
+            phoneNum={phonenumber.replaceAll('-', '')}
+          />
+        )}
+      </View>
+    </>
   );
 };
 

--- a/src/screens/authorize/finds/PasswordResetCompleteScreen/PasswordResetCompleteScreen.tsx
+++ b/src/screens/authorize/finds/PasswordResetCompleteScreen/PasswordResetCompleteScreen.tsx
@@ -1,22 +1,34 @@
-import React from 'react';
-import { View, Image } from 'react-native';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
+import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import Text from 'components/common/Text/Text';
+import { AuthorizeMenu } from 'constants/menu';
+import { Image, View } from 'react-native';
+import { AuthStackParamList } from 'types/apps/menu';
 import passwordResetCompleteScreenStyles from './PasswordResetCompleteScreen.style';
 
 const PasswordResetCompleteScreen = () => {
+  const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
   return (
-    <View style={passwordResetCompleteScreenStyles.authorizeContainer}>
-      <Image
-        style={passwordResetCompleteScreenStyles.checkImage}
-        source={require('../../../../assets/images/check.png')}
-      />
-      <Text variant="h4" color="main">
-        비밀번호 변경이 완료되었습니다.
-      </Text>
-      <Text variant="body2" color="white">
-        다시 로그인을 해주세요.
-      </Text>
-    </View>
+    <ScreenCover
+      authorizeButton={{
+        handlePress: () => navigation.navigate(AuthorizeMenu.Login),
+        label: '로그인 화면으로',
+        isActive: true,
+      }}
+    >
+      <View style={passwordResetCompleteScreenStyles.authorizeContainer}>
+        <Image
+          style={passwordResetCompleteScreenStyles.checkImage}
+          source={require('../../../../assets/images/check.png')}
+        />
+        <Text variant="h4" color="main">
+          비밀번호 변경이 완료되었습니다.
+        </Text>
+        <Text variant="body2" color="white">
+          다시 로그인을 해주세요.
+        </Text>
+      </View>
+    </ScreenCover>
   );
 };
 

--- a/src/screens/authorize/finds/PasswordResetScreen/PasswordResetScreen.tsx
+++ b/src/screens/authorize/finds/PasswordResetScreen/PasswordResetScreen.tsx
@@ -1,22 +1,48 @@
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import EssentialInput from 'components/authorize/inputs/EssentialInput/EssentialInput';
 import Text from 'components/common/Text/Text';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { View } from 'react-native';
 import { validatePassword, validatePasswordCheck } from 'utils/validate';
+import { useResetPassword } from 'hooks/queries/auth';
+import { ApiErrorResponse } from 'types/ApiResponse';
+import DialogContext from 'utils/DialogContext';
 import PasswordResetCompleteScreen from '../PasswordResetCompleteScreen/PasswordResetCompleteScreen';
 import passwordResetScreenStyles from './PasswordResetScreen.style';
 
 interface Props {
   email?: string;
+  phoneNum?: string;
 }
 
-const PasswordResetScreen = ({ email }: Props) => {
+const PasswordResetScreen = ({
+  email = 'error',
+  phoneNum = 'error',
+}: Props) => {
   const [password, setPassword] = useState<string>('');
   const [passwordCheck, setPasswordCheck] = useState<string>('');
   const [isAuthorize, setIsAuthorize] = useState<boolean>(false);
-  const handleChangePassword = () => {
+  const { openDialog } = useContext(DialogContext);
+
+  const handleSuccessCallback = () => {
     setIsAuthorize(true);
+  };
+  const handleErrorCallback = (error: ApiErrorResponse) => {
+    openDialog({
+      text: error.message,
+      type: 'validate',
+    });
+  };
+  const { mutateAsync: resetPassword } = useResetPassword(
+    handleSuccessCallback,
+    handleErrorCallback,
+  );
+  const handleChangePassword = () => {
+    resetPassword({
+      email,
+      phoneNum,
+      newPassword: passwordCheck,
+    });
   };
 
   const isConfirmPassword =

--- a/src/screens/authorize/finds/PasswordResetScreen/PasswordResetScreen.tsx
+++ b/src/screens/authorize/finds/PasswordResetScreen/PasswordResetScreen.tsx
@@ -1,12 +1,14 @@
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import EssentialInput from 'components/authorize/inputs/EssentialInput/EssentialInput';
 import Text from 'components/common/Text/Text';
+import CommonLoading from 'components/suspense/loading/CommonLoading/CommonLoading';
+import { useResetPassword } from 'hooks/queries/auth';
 import { useContext, useState } from 'react';
 import { View } from 'react-native';
-import { validatePassword, validatePasswordCheck } from 'utils/validate';
-import { useResetPassword } from 'hooks/queries/auth';
+import { colors } from 'styles/theme';
 import { ApiErrorResponse } from 'types/ApiResponse';
 import DialogContext from 'utils/DialogContext';
+import { validatePassword, validatePasswordCheck } from 'utils/validate';
 import PasswordResetCompleteScreen from '../PasswordResetCompleteScreen/PasswordResetCompleteScreen';
 import passwordResetScreenStyles from './PasswordResetScreen.style';
 
@@ -33,7 +35,7 @@ const PasswordResetScreen = ({
       type: 'validate',
     });
   };
-  const { mutateAsync: resetPassword } = useResetPassword(
+  const { mutateAsync: resetPassword, isLoading } = useResetPassword(
     handleSuccessCallback,
     handleErrorCallback,
   );
@@ -52,41 +54,46 @@ const PasswordResetScreen = ({
     passwordCheck.length > 1;
 
   return (
-    <View style={passwordResetScreenStyles.container}>
-      {!isAuthorize ? (
-        <ScreenCover
-          authorizeButton={{
-            handlePress: handleChangePassword,
-            label: '다음',
-            isActive: isConfirmPassword,
-          }}
-        >
-          <View style={passwordResetScreenStyles.passwordResetTitle}>
-            <Text variant="h3" color="white">
-              비밀번호를 재설정해주세요.
-            </Text>
-          </View>
-          <EssentialInput
-            validation={validatePassword}
-            label="새 비밀번호"
-            value={password}
-            setValue={setPassword}
-            type="password"
-          />
-          <EssentialInput
-            validation={(check: string) =>
-              validatePasswordCheck(password, check)
-            }
-            label="새 비밀번호 확인"
-            value={passwordCheck}
-            setValue={setPasswordCheck}
-            type="password"
-          />
-        </ScreenCover>
-      ) : (
-        <PasswordResetCompleteScreen />
+    <>
+      {isLoading && (
+        <CommonLoading isActive backgroundColor={colors.background} />
       )}
-    </View>
+      <View style={passwordResetScreenStyles.container}>
+        {!isAuthorize ? (
+          <ScreenCover
+            authorizeButton={{
+              handlePress: handleChangePassword,
+              label: '다음',
+              isActive: isConfirmPassword,
+            }}
+          >
+            <View style={passwordResetScreenStyles.passwordResetTitle}>
+              <Text variant="h3" color="white">
+                비밀번호를 재설정해주세요.
+              </Text>
+            </View>
+            <EssentialInput
+              validation={validatePassword}
+              label="새 비밀번호"
+              value={password}
+              setValue={setPassword}
+              type="password"
+            />
+            <EssentialInput
+              validation={(check: string) =>
+                validatePasswordCheck(password, check)
+              }
+              label="새 비밀번호 확인"
+              value={passwordCheck}
+              setValue={setPasswordCheck}
+              type="password"
+            />
+          </ScreenCover>
+        ) : (
+          <PasswordResetCompleteScreen />
+        )}
+      </View>
+    </>
   );
 };
 

--- a/src/screens/authorize/finds/PasswordResetScreen/PasswordResetScreen.tsx
+++ b/src/screens/authorize/finds/PasswordResetScreen/PasswordResetScreen.tsx
@@ -7,7 +7,11 @@ import { validatePassword, validatePasswordCheck } from 'utils/validate';
 import PasswordResetCompleteScreen from '../PasswordResetCompleteScreen/PasswordResetCompleteScreen';
 import passwordResetScreenStyles from './PasswordResetScreen.style';
 
-const PasswordResetScreen = () => {
+interface Props {
+  email?: string;
+}
+
+const PasswordResetScreen = ({ email }: Props) => {
   const [password, setPassword] = useState<string>('');
   const [passwordCheck, setPasswordCheck] = useState<string>('');
   const [isAuthorize, setIsAuthorize] = useState<boolean>(false);

--- a/src/screens/authorize/joins/AgreeToTermScreen/AgreeToTermScreen.tsx
+++ b/src/screens/authorize/joins/AgreeToTermScreen/AgreeToTermScreen.tsx
@@ -1,10 +1,14 @@
-import { NavigationProp, useNavigation } from '@react-navigation/native';
+import {
+  NavigationProp,
+  useFocusEffect,
+  useNavigation,
+} from '@react-navigation/native';
 import CheckButton from 'components/authorize/buttons/CheckButton/CheckButton';
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import { UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
-import { Dispatch, useEffect, useState } from 'react';
-import { View } from 'react-native';
+import { Dispatch, useCallback, useEffect, useState } from 'react';
+import { BackHandler, View } from 'react-native';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action } from 'types/join';
 import agreeToTermScreenStyles from './AgreeToTermScreen.style';
@@ -26,11 +30,26 @@ const AgreeToTermScreen = ({ dispatch }: Props) => {
     termToPrivacy: false,
     termToMarketing: false,
   });
+
   const handleSingleTerm = (key: string) => {
     setTerm((checkTerm) => {
       return { ...checkTerm, [key]: !checkTerm[key] };
     });
   };
+
+  useFocusEffect(
+    useCallback(() => {
+      const backHandler = BackHandler.addEventListener(
+        'hardwareBackPress',
+        () => {
+          BackHandler.exitApp();
+          return true;
+        },
+      );
+      return () => backHandler.remove();
+    }, []),
+  );
+
   useEffect(() => {
     if (
       term.termToMarketing &&
@@ -52,6 +71,7 @@ const AgreeToTermScreen = ({ dispatch }: Props) => {
     term.termToTeenager,
     term.termToUse,
   ]);
+
   const isActive = term.termToPrivacy && term.termToTeenager && term.termToUse;
   return (
     <ScreenCover

--- a/src/screens/authorize/joins/AgreeToTermScreen/AgreeToTermScreen.tsx
+++ b/src/screens/authorize/joins/AgreeToTermScreen/AgreeToTermScreen.tsx
@@ -97,7 +97,7 @@ const AgreeToTermScreen = ({ dispatch }: Props) => {
               termToMarketing: !term.allAgree,
             });
           }}
-          marginBottom={30}
+          marginBottom={17}
           label="네, 모두 동의합니다."
         />
         <CheckButton

--- a/src/screens/authorize/joins/EmailPasswordScreen/EmailPasswordScreen.tsx
+++ b/src/screens/authorize/joins/EmailPasswordScreen/EmailPasswordScreen.tsx
@@ -1,12 +1,15 @@
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import EssentialInput from 'components/authorize/inputs/EssentialInput/EssentialInput';
+import CommonLoading from 'components/suspense/loading/CommonLoading/CommonLoading';
 import { UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
 import { useEmailCheck, useNormalSignUp } from 'hooks/queries/auth';
-import { Dispatch, useState } from 'react';
+import { Dispatch, useContext, useState } from 'react';
+import { colors } from 'styles/theme';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action } from 'types/join';
+import DialogContext from 'utils/DialogContext';
 import { validateEmail, validatePassword } from 'utils/validate';
 
 interface Props {
@@ -15,12 +18,15 @@ interface Props {
 
 const EmailPasswordScreen = ({ dispatch }: Props) => {
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
+  const { openDialog } = useContext(DialogContext);
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
 
-  const { mutateAsync: checkEmail } = useEmailCheck();
+  const { mutateAsync: checkEmail, isLoading: isEmailCheckLoading } =
+    useEmailCheck();
 
-  const { mutateAsync: normalSignUp } = useNormalSignUp();
+  const { mutateAsync: normalSignUp, isLoading: isNormalSignUpLoading } =
+    useNormalSignUp();
 
   const isActive =
     !validateEmail(email) &&
@@ -28,19 +34,24 @@ const EmailPasswordScreen = ({ dispatch }: Props) => {
     !validatePassword(password) &&
     password.length > 1;
 
-  const handleAuthorize = () => {
-    checkEmail(email)
-      .then(() => {
-        normalSignUp({ email, password });
-      })
-      .then(() => {
-        dispatch({
-          type: UserInfoStatus.SET_EMAIL_ADDRESS_PASSWORD,
-          emailPassword: { email, password },
-        });
-        navigation.navigate(AuthorizeMenu.AgreeToTerm);
-      });
+  const handleNormalSignUp = async () => {
+    await normalSignUp({ email, password });
+    dispatch({
+      type: UserInfoStatus.SET_EMAIL_ADDRESS_PASSWORD,
+      emailPassword: { email, password },
+    });
+    navigation.navigate(AuthorizeMenu.AgreeToTerm);
   };
+
+  const handleAuthorize = async () => {
+    const checkInfo = await checkEmail(email);
+    if (checkInfo.data?.check) handleNormalSignUp();
+    else openDialog({ text: '중복된 이메일입니다.', type: 'validate' });
+  };
+
+  if (isEmailCheckLoading || isNormalSignUpLoading)
+    return <CommonLoading isActive backgroundColor={colors.background} />;
+
   return (
     <ScreenCover
       authorizeButton={{

--- a/src/screens/authorize/joins/EmailPasswordScreen/EmailPasswordScreen.tsx
+++ b/src/screens/authorize/joins/EmailPasswordScreen/EmailPasswordScreen.tsx
@@ -3,6 +3,7 @@ import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import EssentialInput from 'components/authorize/inputs/EssentialInput/EssentialInput';
 import { UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
+import { useEmailCheck, useNormalSignUp } from 'hooks/queries/auth';
 import { Dispatch, useState } from 'react';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action } from 'types/join';
@@ -16,21 +17,34 @@ const EmailPasswordScreen = ({ dispatch }: Props) => {
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
+
+  const { mutateAsync: checkEmail } = useEmailCheck();
+
+  const { mutateAsync: normalSignUp } = useNormalSignUp();
+
   const isActive =
     !validateEmail(email) &&
     email.length > 1 &&
     !validatePassword(password) &&
     password.length > 1;
+
+  const handleAuthorize = () => {
+    checkEmail(email)
+      .then(() => {
+        normalSignUp({ email, password });
+      })
+      .then(() => {
+        dispatch({
+          type: UserInfoStatus.SET_EMAIL_ADDRESS_PASSWORD,
+          emailPassword: { email, password },
+        });
+        navigation.navigate(AuthorizeMenu.AgreeToTerm);
+      });
+  };
   return (
     <ScreenCover
       authorizeButton={{
-        handlePress: () => {
-          dispatch({
-            type: UserInfoStatus.SET_EMAIL_ADDRESS_PASSWORD,
-            emailPassword: { email, password },
-          });
-          navigation.navigate(AuthorizeMenu.AgreeToTerm);
-        },
+        handlePress: handleAuthorize,
         label: '확인',
         isActive,
       }}

--- a/src/screens/authorize/joins/InterestFieldScreen/InterestFieldScreen.style.ts
+++ b/src/screens/authorize/joins/InterestFieldScreen/InterestFieldScreen.style.ts
@@ -1,18 +1,10 @@
 import { StyleSheet } from 'react-native';
-import { colors } from 'styles/theme';
 
 const interestFieldScreenStyles = StyleSheet.create({
-  container: {
-    padding: 20,
-    backgroundColor: colors.background,
-    flex: 1,
-    flexDirection: 'column',
-  },
   fieldInfomation: {
-    marginTop: 20,
+    marginTop: -26,
     width: 198,
     height: 37,
-    marginBottom: 36,
   },
 });
 

--- a/src/screens/authorize/joins/InterestFieldScreen/InterestFieldScreen.tsx
+++ b/src/screens/authorize/joins/InterestFieldScreen/InterestFieldScreen.tsx
@@ -12,6 +12,7 @@ import { colors } from 'styles/theme';
 import { Field } from 'types/apps/group';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action, JoinInfo } from 'types/join';
+import Spacing from 'components/common/Spacing/Spacing';
 import interestFieldScreenStyles from './InterestFieldScreen.style';
 
 interface Props {
@@ -82,6 +83,8 @@ const InterestFieldScreen = ({ state, dispatch }: Props) => {
         style={interestFieldScreenStyles.fieldInfomation}
         source={require('../../../../assets/images/interestFieldInfo.png')}
       />
+      <Spacing height={42} />
+
       <FieldButtonGroup
         fields={interestField}
         setFields={setInterestField}

--- a/src/screens/authorize/joins/InterestFieldScreen/InterestFieldScreen.tsx
+++ b/src/screens/authorize/joins/InterestFieldScreen/InterestFieldScreen.tsx
@@ -11,14 +11,15 @@ import { Image } from 'react-native';
 import { colors } from 'styles/theme';
 import { Field } from 'types/apps/group';
 import { AuthStackParamList } from 'types/apps/menu';
-import { Action } from 'types/join';
+import { Action, JoinInfo } from 'types/join';
 import interestFieldScreenStyles from './InterestFieldScreen.style';
 
 interface Props {
+  state: JoinInfo;
   dispatch: Dispatch<Action>;
 }
 
-const InterestFieldScreen = ({ dispatch }: Props) => {
+const InterestFieldScreen = ({ state, dispatch }: Props) => {
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
   const [interestField, setInterestField] = useState<Field[]>(fieldData);
   const { mutateAsync: concludeOnBoarding, isLoading } =
@@ -38,30 +39,30 @@ const InterestFieldScreen = ({ dispatch }: Props) => {
     return count;
   };
 
-  const handleAuthorize = () => {
-    concludeOnBoarding({
+  const handleAuthorize = async () => {
+    const params = {
       onBoarding: {
-        nickname: '',
-        username: '',
-        gender: 'MAN',
-        year: 0,
-        month: 0,
-        day: 0,
+        nickname: state.nickname,
+        username: state.username,
+        gender: state.gender,
+        year: parseInt(state.birth.substring(0, 4), 10),
+        month: parseInt(state.birth.substring(5, 7), 10),
+        day: parseInt(state.birth.substring(8, 10), 10),
       },
       fields: {
         fieldTypeList: interestField
           .filter((fieldElement) => fieldElement.isActive)
           .map((field) => field.value),
       },
-    }).then(() => {
-      dispatch({
-        type: UserInfoStatus.SET_INTEREST_FIELD,
-        interestField: interestField.filter(
-          (fieldElement) => fieldElement.isActive,
-        ),
-      });
-      navigation.navigate(AuthorizeMenu.JoinComplete);
+    };
+    await concludeOnBoarding(params);
+    dispatch({
+      type: UserInfoStatus.SET_INTEREST_FIELD,
+      interestField: interestField.filter(
+        (fieldElement) => fieldElement.isActive,
+      ),
     });
+    navigation.navigate(AuthorizeMenu.JoinComplete);
   };
 
   if (isLoading) {

--- a/src/screens/authorize/joins/InterestFieldScreen/InterestFieldScreen.tsx
+++ b/src/screens/authorize/joins/InterestFieldScreen/InterestFieldScreen.tsx
@@ -1,11 +1,14 @@
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import FieldButtonGroup from 'components/authorize/groups/FieldButtonGroup/FieldButtonGroup';
+import CommonLoading from 'components/suspense/loading/CommonLoading/CommonLoading';
 import { UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
 import fieldData from 'data/lists/fieldData';
+import { useConcludeOnBoarding } from 'hooks/queries/user';
 import { Dispatch, useEffect, useState } from 'react';
 import { Image } from 'react-native';
+import { colors } from 'styles/theme';
 import { Field } from 'types/apps/group';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action } from 'types/join';
@@ -18,9 +21,13 @@ interface Props {
 const InterestFieldScreen = ({ dispatch }: Props) => {
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
   const [interestField, setInterestField] = useState<Field[]>(fieldData);
+  const { mutateAsync: concludeOnBoarding, isLoading } =
+    useConcludeOnBoarding();
+
   useEffect(() => {
     setInterestField(interestField);
   }, [interestField]);
+
   const computedCount = () => {
     let count = 0;
     interestField.forEach((mappingField) => {
@@ -30,19 +37,42 @@ const InterestFieldScreen = ({ dispatch }: Props) => {
     });
     return count;
   };
+
+  const handleAuthorize = () => {
+    concludeOnBoarding({
+      onBoarding: {
+        nickname: '',
+        username: '',
+        gender: 'MAN',
+        year: 0,
+        month: 0,
+        day: 0,
+      },
+      fields: {
+        fieldTypeList: interestField
+          .filter((fieldElement) => fieldElement.isActive)
+          .map((field) => field.value),
+      },
+    }).then(() => {
+      dispatch({
+        type: UserInfoStatus.SET_INTEREST_FIELD,
+        interestField: interestField.filter(
+          (fieldElement) => fieldElement.isActive,
+        ),
+      });
+      navigation.navigate(AuthorizeMenu.JoinComplete);
+    });
+  };
+
+  if (isLoading) {
+    return <CommonLoading isActive backgroundColor={colors.background} />;
+  }
+
   return (
     <ScreenCover
       titleElements={['관심 분야를 설정해주세요.']}
       authorizeButton={{
-        handlePress: () => {
-          dispatch({
-            type: UserInfoStatus.SET_INTEREST_FIELD,
-            interestField: interestField.filter(
-              (fieldElement) => fieldElement.isActive,
-            ),
-          });
-          navigation.navigate(AuthorizeMenu.JoinComplete);
-        },
+        handlePress: handleAuthorize,
         label: '확인',
         isActive: computedCount() >= 1,
       }}

--- a/src/screens/authorize/joins/JoinCompleteScreen/JoinCompleteScreen.style.ts
+++ b/src/screens/authorize/joins/JoinCompleteScreen/JoinCompleteScreen.style.ts
@@ -9,9 +9,9 @@ const joinCompleteScreenStyles = StyleSheet.create({
     flexDirection: 'column',
   },
   myFieldTitle: {
-    color: colors.white,
     fontFamily: fonts.regular,
     fontSize: 18,
+    lineHeight: 25.2,
   },
   myFieldContainer: {
     width: '100%',
@@ -22,6 +22,7 @@ const joinCompleteScreenStyles = StyleSheet.create({
     color: colors.main,
     fontFamily: fonts.regular,
     fontSize: 18,
+    lineHeight: 25.2,
     marginRight: 10,
   },
 });

--- a/src/screens/authorize/joins/JoinCompleteScreen/JoinCompleteScreen.tsx
+++ b/src/screens/authorize/joins/JoinCompleteScreen/JoinCompleteScreen.tsx
@@ -1,17 +1,18 @@
+import { useFocusEffect } from '@react-navigation/native';
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import Text from 'components/common/Text/Text';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { BackHandler, View } from 'react-native';
+import { useAuthorizeStore } from 'stores/Authorize';
 import { JoinInfo } from 'types/join';
-import { useFocusEffect } from '@react-navigation/native';
 import joinCompleteScreenStyles from './JoinCompleteScreen.style';
 
 interface Props {
   state: JoinInfo;
-  setIsLogin: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const JoinCompleteScreen = ({ state, setIsLogin }: Props) => {
+const JoinCompleteScreen = ({ state }: Props) => {
+  const { setIsLogin } = useAuthorizeStore();
   useFocusEffect(
     useCallback(() => {
       const backAction = () => {

--- a/src/screens/authorize/joins/NickNameScreen/NickNameScreen.tsx
+++ b/src/screens/authorize/joins/NickNameScreen/NickNameScreen.tsx
@@ -1,11 +1,15 @@
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import EssentialInput from 'components/authorize/inputs/EssentialInput/EssentialInput';
+import CommonLoading from 'components/suspense/loading/CommonLoading/CommonLoading';
 import { UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
-import { Dispatch, useState } from 'react';
+import { useNicknameCheck } from 'hooks/queries/auth';
+import { Dispatch, useContext, useState } from 'react';
+import { colors } from 'styles/theme';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action } from 'types/join';
+import DialogContext from 'utils/DialogContext';
 import { validateNickname } from 'utils/validate';
 
 interface Props {
@@ -16,14 +20,32 @@ const NickNameScreen = ({ dispatch }: Props) => {
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
   const [nickname, setNickname] = useState<string>('');
   const isActive = !validateNickname(nickname) && nickname.length > 1;
+  const { openDialog } = useContext(DialogContext);
+
+  const { mutateAsync: checkNickname, isLoading: isCheckNickname } =
+    useNicknameCheck();
+
+  const handleAuthorize = async () => {
+    const checkInfo = await checkNickname(nickname);
+    if (checkInfo.data?.isExist) {
+      openDialog({
+        type: 'validate',
+        text: '중복된 닉네임입니다. 다시 설정해주세요.',
+      });
+      return;
+    }
+    dispatch({ type: UserInfoStatus.SET_NICK_NAME, nickname });
+    navigation.navigate(AuthorizeMenu.UserInfo);
+  };
+
+  if (isCheckNickname)
+    return <CommonLoading isActive backgroundColor={colors.background} />;
+
   return (
     <ScreenCover
       titleElements={['오픈오프에서 사용할', '닉네임을 입력해주세요.']}
       authorizeButton={{
-        handlePress: () => {
-          dispatch({ type: UserInfoStatus.SET_NICK_NAME, nickname });
-          navigation.navigate(AuthorizeMenu.UserInfo);
-        },
+        handlePress: handleAuthorize,
         label: '확인',
         isActive,
       }}

--- a/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
+++ b/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
@@ -3,9 +3,11 @@ import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import PhoneCertificationForm from 'components/authorize/forms/PhoneCertificationForm/PhoneCertificationForm';
 import { UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
-import { Dispatch, useState } from 'react';
+import { useCheckSms, useSendSms } from 'hooks/queries/user';
+import { Dispatch, useContext, useState } from 'react';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action } from 'types/join';
+import DialogContext from 'utils/DialogContext';
 import { validateAuthNumber, validatePhoneNumber } from 'utils/validate';
 
 interface Props {
@@ -13,13 +15,19 @@ interface Props {
 }
 
 const PhoneCertificationScreen = ({ dispatch }: Props) => {
+  const { openDialog } = useContext(DialogContext);
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
   const [phonenumber, setPhonenumber] = useState<string>('');
   const [authnumber, setAuthnumber] = useState<string>('');
   const [retry, setRetry] = useState<boolean>(false);
-  const handleCertification = () => {
-    setRetry(true);
+
+  const handleSendSmsSuccess = () => {
+    openDialog({
+      type: 'success',
+      text: '인증번호를 발송하였습니다.',
+    });
   };
+
   const handleAuthorizeFlow = () => {
     dispatch({
       type: UserInfoStatus.SET_PHONE_NUMBER,
@@ -27,16 +35,42 @@ const PhoneCertificationScreen = ({ dispatch }: Props) => {
     });
     navigation.navigate(AuthorizeMenu.Nickname);
   };
+
+  const handleCheckSmsSuccess = () => {
+    openDialog({
+      type: 'success',
+      text: '핸드폰 인증이 완료되었습니다.',
+      callback: handleAuthorizeFlow,
+    });
+  };
+
+  const { mutateAsync: sendSms } = useSendSms(handleSendSmsSuccess);
+  const { mutateAsync: checkSms } = useCheckSms(handleCheckSmsSuccess);
+
+  const handleCertification = () => {
+    sendSms({
+      content: '핸드폰 인증',
+      to: phonenumber.replaceAll('-', ''),
+    }).then(() => {
+      setRetry(true);
+    });
+  };
+
   const isActive =
     !validatePhoneNumber(phonenumber) &&
     phonenumber.length > 1 &&
     !validateAuthNumber(authnumber) &&
     authnumber.length > 1 &&
     retry;
+
   return (
     <ScreenCover
       authorizeButton={{
-        handlePress: handleAuthorizeFlow,
+        handlePress: () =>
+          checkSms({
+            phoneNum: phonenumber.replaceAll('-', ''),
+            checkNum: authnumber,
+          }),
         label: '다음',
         isActive,
       }}

--- a/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
+++ b/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
@@ -37,6 +37,13 @@ const PhoneCertificationScreen = ({ dispatch }: Props) => {
   };
 
   const handleCheckSmsError = (error: ApiErrorResponse) => {
+    if (error.response?.data.code === 1003) {
+      openDialog({
+        type: 'validate',
+        text: error.response?.data.message,
+      });
+      return;
+    }
     openDialog({
       type: 'validate',
       text: error.message,

--- a/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
+++ b/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
@@ -47,13 +47,12 @@ const PhoneCertificationScreen = ({ dispatch }: Props) => {
   const { mutateAsync: sendSms } = useSendSms(handleSendSmsSuccess);
   const { mutateAsync: checkSms } = useCheckSms(handleCheckSmsSuccess);
 
-  const handleCertification = () => {
-    sendSms({
+  const handleCertification = async () => {
+    await sendSms({
       content: '핸드폰 인증',
       to: phonenumber.replaceAll('-', ''),
-    }).then(() => {
-      setRetry(true);
     });
+    setRetry(true);
   };
 
   const isActive =

--- a/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
+++ b/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
@@ -3,12 +3,13 @@ import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import PhoneCertificationForm from 'components/authorize/forms/PhoneCertificationForm/PhoneCertificationForm';
 import { UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
+import usePhoneCertificate from 'hooks/authorize/usePhoneCertificate';
 import { useCheckSms, useSendSms } from 'hooks/queries/user';
-import { Dispatch, useContext, useState } from 'react';
+import { Dispatch, useContext } from 'react';
+import { ApiErrorResponse } from 'types/ApiResponse';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action } from 'types/join';
 import DialogContext from 'utils/DialogContext';
-import { validateAuthNumber, validatePhoneNumber } from 'utils/validate';
 
 interface Props {
   dispatch: Dispatch<Action>;
@@ -17,16 +18,15 @@ interface Props {
 const PhoneCertificationScreen = ({ dispatch }: Props) => {
   const { openDialog } = useContext(DialogContext);
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
-  const [phonenumber, setPhonenumber] = useState<string>('');
-  const [authnumber, setAuthnumber] = useState<string>('');
-  const [retry, setRetry] = useState<boolean>(false);
-
-  const handleSendSmsSuccess = () => {
-    openDialog({
-      type: 'success',
-      text: '인증번호를 발송하였습니다.',
-    });
-  };
+  const {
+    phonenumber,
+    setPhonenumber,
+    authnumber,
+    setAuthnumber,
+    retry,
+    setRetry,
+    isActive,
+  } = usePhoneCertificate();
 
   const handleAuthorizeFlow = () => {
     dispatch({
@@ -36,16 +36,25 @@ const PhoneCertificationScreen = ({ dispatch }: Props) => {
     navigation.navigate(AuthorizeMenu.Nickname);
   };
 
-  const handleCheckSmsSuccess = () => {
+  const handleCheckSmsError = (error: ApiErrorResponse) => {
+    openDialog({
+      type: 'validate',
+      text: error.message,
+    });
+  };
+
+  const handleSendSmsSuccess = () => {
     openDialog({
       type: 'success',
-      text: '핸드폰 인증이 완료되었습니다.',
-      callback: handleAuthorizeFlow,
+      text: '인증번호를 발송하였습니다.',
     });
   };
 
   const { mutateAsync: sendSms } = useSendSms(handleSendSmsSuccess);
-  const { mutateAsync: checkSms } = useCheckSms(handleCheckSmsSuccess);
+  const { mutateAsync: checkSms } = useCheckSms(
+    handleAuthorizeFlow,
+    handleCheckSmsError,
+  );
 
   const handleCertification = async () => {
     await sendSms({
@@ -54,13 +63,6 @@ const PhoneCertificationScreen = ({ dispatch }: Props) => {
     });
     setRetry(true);
   };
-
-  const isActive =
-    !validatePhoneNumber(phonenumber) &&
-    phonenumber.length > 1 &&
-    !validateAuthNumber(authnumber) &&
-    authnumber.length > 1 &&
-    retry;
 
   return (
     <ScreenCover

--- a/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
+++ b/src/screens/authorize/joins/PhoneCertificationScreen/PhoneCertificationScreen.tsx
@@ -40,7 +40,7 @@ const PhoneCertificationScreen = ({ dispatch }: Props) => {
     if (error.response?.data.code === 1003) {
       openDialog({
         type: 'validate',
-        text: error.response?.data.message,
+        text: '이미 회원정보가 있는 핸드폰 번호입니다.',
       });
       return;
     }

--- a/src/screens/authorize/joins/UserInfoScreen/UserInfoScreen.style.ts
+++ b/src/screens/authorize/joins/UserInfoScreen/UserInfoScreen.style.ts
@@ -1,16 +1,11 @@
 import { StyleSheet } from 'react-native';
-import { colors } from 'styles/theme';
 
 const userInfoScreenStyles = StyleSheet.create({
-  container: {
-    position: 'relative',
-    flex: 1,
-    alignItems: 'center',
-    backgroundColor: colors.background,
-  },
   detailUserInfo: {
+    flex: 1,
     flexDirection: 'row',
     marginTop: 70,
+    gap: 10,
   },
 });
 

--- a/src/screens/authorize/joins/UserInfoScreen/UserInfoScreen.tsx
+++ b/src/screens/authorize/joins/UserInfoScreen/UserInfoScreen.tsx
@@ -17,30 +17,34 @@ interface Props {
 
 const UserInfoScreen = ({ dispatch }: Props) => {
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
-  const [name, setName] = useState<string>('');
+  const [username, setUsername] = useState<string>('');
   const [birth, setBirth] = useState<string>('2000-00-00');
   const [gender, setGender] = useState<Gender>('MAN');
+
   const isActive =
-    !validateName(name) && !validateBirthday(birth) && name.length > 1;
+    !validateName(username) && !validateBirthday(birth) && username.length > 1;
+
+  const handleAuthorizeFlow = () => {
+    dispatch({ type: UserInfoStatus.SET_NAME, username });
+    dispatch({ type: UserInfoStatus.SET_GENDER, gender });
+    dispatch({ type: UserInfoStatus.SET_BIRTH, birth });
+    navigation.navigate(AuthorizeMenu.InterestField);
+  };
+
   return (
     <ScreenCover
       titleElements={['오픈오프 이용을 위해', '정보를 입력해주세요.']}
       authorizeButton={{
-        handlePress: () => {
-          dispatch({ type: UserInfoStatus.SET_NAME, name });
-          dispatch({ type: UserInfoStatus.SET_GENDER, gender });
-          dispatch({ type: UserInfoStatus.SET_BIRTH, birth });
-          navigation.navigate(AuthorizeMenu.InterestField);
-        },
+        handlePress: handleAuthorizeFlow,
         label: '확인',
         isActive,
       }}
     >
       <BaseInfoInput
         label="이름"
-        value={name}
+        value={username}
         width={Dimensions.get('window').width - 50}
-        setValue={setName}
+        setValue={setUsername}
         validation={validateName}
       />
       <View style={userInfoScreenStyles.detailUserInfo}>

--- a/src/screens/authorize/joins/UserInfoScreen/UserInfoScreen.tsx
+++ b/src/screens/authorize/joins/UserInfoScreen/UserInfoScreen.tsx
@@ -7,7 +7,7 @@ import { AuthorizeMenu } from 'constants/menu';
 import { Dispatch, useState } from 'react';
 import { Dimensions, View } from 'react-native';
 import { AuthStackParamList } from 'types/apps/menu';
-import { Action } from 'types/join';
+import { Action, Gender } from 'types/join';
 import { validateBirthday, validateName } from 'utils/validate';
 import userInfoScreenStyles from './UserInfoScreen.style';
 
@@ -19,7 +19,7 @@ const UserInfoScreen = ({ dispatch }: Props) => {
   const navigation = useNavigation<NavigationProp<AuthStackParamList>>();
   const [name, setName] = useState<string>('');
   const [birth, setBirth] = useState<string>('2000-00-00');
-  const [gender, setGender] = useState<'남' | '여'>('남');
+  const [gender, setGender] = useState<Gender>('MAN');
   const isActive =
     !validateName(name) && !validateBirthday(birth) && name.length > 1;
   return (

--- a/src/screens/authorize/joins/UserInfoScreen/UserInfoScreen.tsx
+++ b/src/screens/authorize/joins/UserInfoScreen/UserInfoScreen.tsx
@@ -5,7 +5,7 @@ import GenderInput from 'components/authorize/inputs/GenderInput/GenderInput';
 import { UserInfoStatus } from 'constants/join';
 import { AuthorizeMenu } from 'constants/menu';
 import { Dispatch, useState } from 'react';
-import { Dimensions, View } from 'react-native';
+import { View } from 'react-native';
 import { AuthStackParamList } from 'types/apps/menu';
 import { Action, Gender } from 'types/join';
 import { validateBirthday, validateName } from 'utils/validate';
@@ -43,7 +43,6 @@ const UserInfoScreen = ({ dispatch }: Props) => {
       <BaseInfoInput
         label="이름"
         value={username}
-        width={Dimensions.get('window').width - 50}
         setValue={setUsername}
         validation={validateName}
       />
@@ -51,7 +50,6 @@ const UserInfoScreen = ({ dispatch }: Props) => {
         <BaseInfoInput
           label="생일"
           value={birth}
-          width={Dimensions.get('window').width / 2 - 32}
           setValue={setBirth}
           validation={validateBirthday}
           focusMode

--- a/src/screens/authorize/logins/LoginScreen/LoginScreen.style.ts
+++ b/src/screens/authorize/logins/LoginScreen/LoginScreen.style.ts
@@ -1,25 +1,29 @@
 import { StyleSheet } from 'react-native';
-import { colors } from 'styles/theme';
+import { colors, fonts } from 'styles/theme';
 
 const loginScreenStyles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
     alignItems: 'center',
-    paddingHorizontal: 20,
+    paddingHorizontal: 25,
+    paddingBottom: 30,
+  },
+  mainContainer: {
+    flex: 1,
+    width: '100%',
+    justifyContent: 'center',
+    gap: 30,
   },
   logo: {
     marginTop: 13,
-    marginBottom: 62,
     width: 110,
     height: 102,
   },
   middleText: {
-    marginTop: 30,
-    marginBottom: 10,
-  },
-  joinAndFindContainer: {
-    marginTop: 25,
+    fontFamily: fonts.regular,
+    fontSize: 13,
+    alignSelf: 'center',
   },
 });
 

--- a/src/screens/authorize/logins/LoginScreen/LoginScreen.tsx
+++ b/src/screens/authorize/logins/LoginScreen/LoginScreen.tsx
@@ -1,6 +1,6 @@
 import { loginWithKakaoAccount } from '@react-native-seoul/kakao-login';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
-import { clearToken } from 'apis';
+import { applyToken, clearToken } from 'apis';
 import { getMyInfo } from 'apis/user';
 import { AxiosError } from 'axios';
 import JoinButton from 'components/authorize/buttons/JoinAndFindButton/JoinAndFindButton';
@@ -70,6 +70,7 @@ const LoginScreen = () => {
           accessToken: socialToken.data?.accessToken,
           refreshToken: socialToken.data?.refreshToken,
         });
+        applyToken(socialToken.data?.accessToken ?? '');
         return getMyInfo();
       })
       .then((data) => {
@@ -89,6 +90,7 @@ const LoginScreen = () => {
           accessToken: normalToken.data?.accessToken,
           refreshToken: normalToken.data?.refreshToken,
         });
+        applyToken(normalToken.data?.accessToken ?? '');
         return getMyInfo();
       })
       .then((data) => {

--- a/src/screens/authorize/logins/LoginScreen/LoginScreen.tsx
+++ b/src/screens/authorize/logins/LoginScreen/LoginScreen.tsx
@@ -99,39 +99,38 @@ const LoginScreen = () => {
         style={loginScreenStyles.logo}
         source={require('../../../../assets/images/logo.png')}
       />
-      <LoginInput
-        label="이메일"
-        value={emailAddress}
-        type="emailAddress"
-        validation={validateEmail}
-        setValue={setEmailAddress}
-      />
-      <LoginInput
-        label="비밀번호"
-        value={password}
-        type="password"
-        setValue={setPassword}
-        validation={validatePassword}
-      />
-      <LoginButton isActive={isActive} handlePress={handleCommonLogin} />
-      <Text variant="caption" style={loginScreenStyles.middleText}>
-        또는
-      </Text>
-      <SocialLoginButtonGroup
-        kakaoLogin={handleKakaoLogin}
-        naverLogin={() => {
-          return false;
-        }}
-        googleLogin={() => {
-          return false;
-        }}
-        appleLogin={() => {
-          return false;
-        }}
-      />
-      <View style={loginScreenStyles.joinAndFindContainer}>
-        <JoinButton />
+      <View style={loginScreenStyles.mainContainer}>
+        <LoginInput
+          label="이메일"
+          value={emailAddress}
+          type="emailAddress"
+          validation={validateEmail}
+          setValue={setEmailAddress}
+        />
+        <LoginInput
+          label="비밀번호"
+          value={password}
+          type="password"
+          setValue={setPassword}
+          validation={validatePassword}
+        />
+        <LoginButton isActive={isActive} handlePress={handleCommonLogin} />
+        <Text style={loginScreenStyles.middleText}>또는</Text>
+        <SocialLoginButtonGroup
+          kakaoLogin={handleKakaoLogin}
+          naverLogin={() => {
+            return false;
+          }}
+          googleLogin={() => {
+            return false;
+          }}
+          appleLogin={() => {
+            return false;
+          }}
+        />
       </View>
+
+      <JoinButton />
     </View>
   );
 };

--- a/src/screens/authorize/logins/LoginScreen/LoginScreen.tsx
+++ b/src/screens/authorize/logins/LoginScreen/LoginScreen.tsx
@@ -17,6 +17,7 @@ import { ApiResponse } from 'types/ApiResponse';
 import { AuthStackParamList } from 'types/apps/menu';
 import DialogContext from 'utils/DialogContext';
 import { validateEmail, validatePassword } from 'utils/validate';
+import UserTotalInfoResponseDto from 'models/user/response/UserTotalInfoResponseDto';
 import loginScreenStyles from './LoginScreen.style';
 
 const LoginScreen = () => {
@@ -59,12 +60,18 @@ const LoginScreen = () => {
     emailAddress.length >= 1 &&
     password.length >= 1;
 
-  const divergeAuthorizeFlow = (userName?: string) => {
-    if (userName) {
+  const divergeAuthorizeFlow = (
+    userInfo?: UserTotalInfoResponseDto['userInfo'],
+  ) => {
+    if (userInfo?.userName) {
       setIsLogin(true);
-    } else {
-      navigation.navigate('AgreeToTerm');
+      return;
     }
+    if (userInfo?.phoneNumber) {
+      navigation.navigate('Nickname');
+      return;
+    }
+    navigation.navigate('AgreeToTerm');
   };
 
   const handleKakaoLogin = async () => {
@@ -73,7 +80,7 @@ const LoginScreen = () => {
       socialType: 'kakao',
       token: kakaoResult.idToken,
     });
-    divergeAuthorizeFlow(socialLoginResult.data?.userInfo.userName);
+    divergeAuthorizeFlow(socialLoginResult.data?.userInfo);
   };
 
   const handleCommonLogin = async () => {
@@ -82,7 +89,7 @@ const LoginScreen = () => {
       email: emailAddress,
       password,
     });
-    divergeAuthorizeFlow(normalLoginResult.data?.userInfo.userName);
+    divergeAuthorizeFlow(normalLoginResult.data?.userInfo);
   };
 
   useEffect(() => {

--- a/src/screens/authorize/logins/LoginScreen/LoginScreen.tsx
+++ b/src/screens/authorize/logins/LoginScreen/LoginScreen.tsx
@@ -67,21 +67,22 @@ const LoginScreen = () => {
     }
   };
 
-  const handleKakaoLogin = () => {
-    loginWithKakaoAccount()
-      .then((result) => {
-        return socialLogin({ socialType: 'kakao', token: result.idToken });
-      })
-      .then((data) => {
-        divergeAuthorizeFlow(data.data?.userInfo.userName);
-      });
+  const handleKakaoLogin = async () => {
+    const kakaoResult = await loginWithKakaoAccount();
+    const socialLoginResult = await socialLogin({
+      socialType: 'kakao',
+      token: kakaoResult.idToken,
+    });
+    divergeAuthorizeFlow(socialLoginResult.data?.userInfo.userName);
   };
 
-  const handleCommonLogin = () => {
+  const handleCommonLogin = async () => {
     if (!isActive) return;
-    normalLogin({ email: emailAddress, password }).then((data) => {
-      divergeAuthorizeFlow(data.data?.userInfo.userName);
+    const normalLoginResult = await normalLogin({
+      email: emailAddress,
+      password,
     });
+    divergeAuthorizeFlow(normalLoginResult.data?.userInfo.userName);
   };
 
   useEffect(() => {

--- a/src/stores/Authorize.ts
+++ b/src/stores/Authorize.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 interface Token {
   accessToken: string | undefined;
@@ -21,27 +23,35 @@ const initAuthorize = {
   isLogin: false,
 };
 
-export const useAuthorizeStore = create<AuthorizeStore>((set) => ({
-  ...initAuthorize,
-  setToken: (payload) =>
-    set((state) => ({
-      ...state,
-      token: {
-        accessToken: payload.accessToken,
-        refreshToken: payload.refreshToken,
-      },
-    })),
-  resetToken: () =>
-    set((state) => ({
-      ...state,
-      token: {
-        accessToken: undefined,
-        refreshToken: undefined,
-      },
-    })),
-  setIsLogin: (payload) =>
-    set((state) => ({
-      ...state,
-      isLogin: payload,
-    })),
-}));
+export const useAuthorizeStore = create<AuthorizeStore>()(
+  persist(
+    (set) => ({
+      ...initAuthorize,
+      setToken: (payload) =>
+        set((state) => ({
+          ...state,
+          token: {
+            accessToken: payload.accessToken,
+            refreshToken: payload.refreshToken,
+          },
+        })),
+      resetToken: () =>
+        set((state) => ({
+          ...state,
+          token: {
+            accessToken: undefined,
+            refreshToken: undefined,
+          },
+        })),
+      setIsLogin: (payload) =>
+        set((state) => ({
+          ...state,
+          isLogin: payload,
+        })),
+    }),
+    {
+      name: 'authorize',
+      storage: createJSONStorage(() => AsyncStorage),
+    },
+  ),
+);

--- a/src/stores/Authorize.ts
+++ b/src/stores/Authorize.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+
+interface Token {
+  accessToken: string | undefined;
+  refreshToken: string | undefined;
+}
+
+export interface AuthorizeStore {
+  token: Token;
+  isLogin: boolean;
+  setToken: (token: Token) => void;
+  resetToken: () => void;
+  setIsLogin: (loginStatus: boolean) => void;
+}
+
+const initAuthorize = {
+  token: {
+    accessToken: undefined,
+    refreshToken: undefined,
+  },
+  isLogin: false,
+};
+
+export const useAuthorizeStore = create<AuthorizeStore>((set) => ({
+  ...initAuthorize,
+  setToken: (payload) =>
+    set((state) => ({
+      ...state,
+      token: {
+        accessToken: payload.accessToken,
+        refreshToken: payload.refreshToken,
+      },
+    })),
+  resetToken: () =>
+    set((state) => ({
+      ...state,
+      token: {
+        accessToken: undefined,
+        refreshToken: undefined,
+      },
+    })),
+  setIsLogin: (payload) =>
+    set((state) => ({
+      ...state,
+      isLogin: payload,
+    })),
+}));

--- a/src/stores/EventMap.ts
+++ b/src/stores/EventMap.ts
@@ -10,7 +10,7 @@ export interface EventMapStore {
   setStartEndDate: (date: StartEndDate) => void;
 }
 
-const initApp = {
+const initEventMap = {
   startEndDate: {
     startDay: '',
     endDay: '',
@@ -18,7 +18,7 @@ const initApp = {
 };
 
 export const useEventMapStore = create<EventMapStore>((set) => ({
-  ...initApp,
+  ...initEventMap,
   setStartEndDate: (payload) =>
     set((state) => ({
       ...state,

--- a/src/styles/textStyles.tsx
+++ b/src/styles/textStyles.tsx
@@ -19,7 +19,7 @@ const textStyles = StyleSheet.create({
   } as TextStyle,
   h4: {
     fontFamily: fonts.bold,
-    fontSize: 18,
+    fontSize: 17,
     lineHeight: 25.2,
   } as TextStyle,
   body1: {

--- a/src/styles/textStyles.tsx
+++ b/src/styles/textStyles.tsx
@@ -23,9 +23,9 @@ const textStyles = StyleSheet.create({
     lineHeight: 25.2,
   } as TextStyle,
   body1: {
-    fontFamily: fonts.bold,
-    fontSize: 16,
-    lineHeight: 22.4,
+    fontFamily: fonts.regular,
+    fontSize: 18,
+    lineHeight: 25.2,
   } as TextStyle,
   body2: {
     fontFamily: fonts.regular,

--- a/src/types/join.ts
+++ b/src/types/join.ts
@@ -6,7 +6,7 @@ interface EmailPassword {
   password: string;
 }
 
-type Gender = '남' | '여';
+type Gender = 'MAN' | 'WOMAN';
 
 type Action =
   | { type: UserInfoStatus.SET_NAME; name: string }

--- a/src/types/join.ts
+++ b/src/types/join.ts
@@ -9,7 +9,7 @@ interface EmailPassword {
 type Gender = 'MAN' | 'WOMAN';
 
 type Action =
-  | { type: UserInfoStatus.SET_NAME; name: string }
+  | { type: UserInfoStatus.SET_NAME; username: string }
   | { type: UserInfoStatus.SET_BIRTH; birth: string }
   | {
       type: UserInfoStatus.SET_EMAIL_ADDRESS_PASSWORD;
@@ -21,11 +21,11 @@ type Action =
   | { type: UserInfoStatus.SET_NICK_NAME; nickname: string }
   | { type: UserInfoStatus.SET_PHONE_NUMBER; phoneNumber: string };
 interface JoinInfo {
-  name: string;
+  username: string;
   birth: string;
   agreeToTerm: string;
   phoneNumber: string;
-  gender: string;
+  gender: Gender;
   nickname: string;
   emailAddress: string;
   password: string;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,9 @@
+interface SocialAccountInfo {
+  id: string;
+  accountType: 'KAKAO' | 'GOOGLE' | 'APPLE';
+  socialId: string;
+  email: string;
+  socialName: string;
+}
+
+export default SocialAccountInfo;


### PR DESCRIPTION
<!-- ⭐️ PR 제목은 한글로 적어주세요 -->

### PR Type

<!-- 해당되는 것들을 제외하곤 지워주세요. -->

- [x] 💫 기능추가

### OS별 테스트 여부

- [x] android
- [x] ios

### 작업 내용

<!-- 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다. -->

- access & refresh 토큰과 로그인 유무 정보를 담아둘 수 있는 스토어를 구현했습니다.
- 소셜로그인 일반로그인에 API를 적용시켰습니다.
- refresh API를 fetcher에 적용시켰습니다.
- 회원가입시 이메일 중복체크를 하는 API를 적용시켰습니다.
- sms인증 API를 적용시켰습니다.
- 구현에 필요한 DTO들을 작성해두었습니다.

### 링크

<!-- 이슈 번호를 '#'뒤에 작성해주세요! (ex. resolved #11) -->

- resolved #71 

### 기타 사항

<!-- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등이 있다면 자유롭게 적어주세요. -->

- 일단 현재까지 붙여놓은 API들은 refresh제외하고 모두 정상동작하는거 확인했어요~!
- 승쪽이랑 얘기를 좀 나눠보니까, 일반회원가입시 이메일 비밀번호 입력 후에 이용약관 페이지로 넘어가고 다시 뒤로가기를 눌러 이메일 비밀번호를 누르게해선 안되겠더라구요! 그래서 이용약관 페이지에서는 뒤로가기가 막히도록 만들었어요ㅎㅎ

<!-- assignees와 reviewers를 설정했는지 확인해주세요. -->
