### PR TITLE
feat: refetch 기능 강화

### DIFF
--- a/src/components/eventDetail/atoms/comments/CommentInput/CommentInput.tsx
+++ b/src/components/eventDetail/atoms/comments/CommentInput/CommentInput.tsx
@@ -11,7 +11,7 @@ import { ChildCommentWriteRequestDto } from 'models/comment/request/ChildComment
 import { ParentCommentWriteRequestDto } from 'models/comment/request/ParentCommentWriteRequestDto';
 import useDialog from 'hooks/app/useDialog';
 import API_ERROR_MESSAGE from 'constants/errorMessage';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { ApiErrorResponse } from 'types/ApiResponse';
 import commentInputStyles from './CommentInput.style';
 

--- a/src/components/eventMap/groups/SelectBoxGroup/SelectBoxGroup.tsx
+++ b/src/components/eventMap/groups/SelectBoxGroup/SelectBoxGroup.tsx
@@ -10,7 +10,7 @@ import { Dispatch } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { Action, Option, SelectBox } from 'types/apps/selectbox';
 import { useQueryClient } from '@tanstack/react-query';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import selectBoxGroup from './SelectBoxGroup.style';
 
 interface Props {

--- a/src/components/eventMap/groups/SelectDetailGroup/SelectDetailGroup.tsx
+++ b/src/components/eventMap/groups/SelectDetailGroup/SelectDetailGroup.tsx
@@ -3,7 +3,7 @@ import Icon from 'components/common/Icon/Icon';
 import Text from 'components/common/Text/Text';
 import SelectControlButton from 'components/eventMap/buttons/SelectControlButton/SelectControlButton';
 import SelectDetailBox from 'components/eventMap/selectboxes/SelectDetailBox/SelectDetailBox';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { SelectStatus } from 'constants/selectBox';
 import {
   applicationAbleOptions,

--- a/src/components/home/buttons/BookmarkButton/BookmarkButton.tsx
+++ b/src/components/home/buttons/BookmarkButton/BookmarkButton.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import Icon from 'components/common/Icon/Icon';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { useBookmark } from 'hooks/queries/bookmark';
 import { ComponentProps, useEffect, useState } from 'react';
 import { TouchableOpacity } from 'react-native';

--- a/src/components/suspense/skeleton/EventCardSkeleton/EventCardSkeleton.tsx
+++ b/src/components/suspense/skeleton/EventCardSkeleton/EventCardSkeleton.tsx
@@ -1,6 +1,6 @@
 import { Dimensions, View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
-import { colors } from 'styles/theme';
+import { colors, layouts } from 'styles/theme';
 import eventCardSkeletonStyles from './EventCardSkeleton.style';
 
 interface Props {
@@ -9,7 +9,9 @@ interface Props {
 
 const EventCardSkeleton = ({ type = 'default' }: Props) => {
   const calcWidth =
-    type === 'default' ? 200 : Dimensions.get('window').width / 2 - 35;
+    type === 'default'
+      ? 200
+      : Dimensions.get('window').width / 2 - layouts.PADDING - 10;
   return (
     <SkeletonPlaceholder backgroundColor={colors.grey}>
       <View style={eventCardSkeletonStyles.container}>

--- a/src/components/user/buttons/UserProfileImageButton/UserProfileImageButton.tsx
+++ b/src/components/user/buttons/UserProfileImageButton/UserProfileImageButton.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import Icon from 'components/common/Icon/Icon';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import MENT_USER from 'constants/user/userConstants';
 import useDialog from 'hooks/app/useDialog';
 import {

--- a/src/components/userEvent/host/StaffList/StaffList.tsx
+++ b/src/components/userEvent/host/StaffList/StaffList.tsx
@@ -21,7 +21,7 @@ import useDialog from 'hooks/app/useDialog';
 import MENT_OPEN_EVENT from 'constants/openEvent/openEventConstants';
 import useUniqueName from 'hooks/ledger/useUniqueName';
 import { useQueryClient } from '@tanstack/react-query';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { ApiErrorResponse } from 'types/ApiResponse';
 import API_ERROR_MESSAGE from 'constants/errorMessage';
 import staffListStyles from './StaffList.style';

--- a/src/components/userEvent/host/UserCard/UserCard.tsx
+++ b/src/components/userEvent/host/UserCard/UserCard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { ActivityIndicator, TouchableOpacity, View } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { ApiErrorResponse } from 'types/ApiResponse';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import API_ERROR_MESSAGE from 'constants/errorMessage';
 import Icon from 'components/common/Icon/Icon';
 import SpaceLayout from 'components/layout/Space/SpaceLayout';

--- a/src/components/userEvent/host/UserHeader/UserHeader.tsx
+++ b/src/components/userEvent/host/UserHeader/UserHeader.tsx
@@ -7,7 +7,7 @@ import API_ERROR_MESSAGE from 'constants/errorMessage';
 import { useQueryClient } from '@tanstack/react-query';
 import useNavigator from 'hooks/navigator/useNavigator';
 import useDialog from 'hooks/app/useDialog';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { ApiErrorResponse } from 'types/ApiResponse';
 import {
   useCancelPermittedApplicant,

--- a/src/constants/queries/queryKeys.ts
+++ b/src/constants/queries/queryKeys.ts
@@ -1,5 +1,5 @@
 import SortType from 'models/ledger/entity/SortType';
-import { FieldCode } from './interest';
+import { FieldCode } from '../interest';
 
 const DOMAIN = {
   USER: 'USER',

--- a/src/constants/queries/resetQueryKey.ts
+++ b/src/constants/queries/resetQueryKey.ts
@@ -1,6 +1,19 @@
 import { FieldCode } from 'constants/interest';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import SortType from 'models/ledger/entity/SortType';
+
+/**
+ * 알림이 울릴 때 갱신되어야 합니다.
+ TODO 알림 종류에 따라 다르게
+ */
+const all = [
+  queryKeys.eventKeys.all,
+  queryKeys.participantKeys.all,
+  queryKeys.hostKeys.all,
+  queryKeys.bookmarkKeys.all,
+  queryKeys.commentKeys.all,
+  queryKeys.ledgerKeys.all,
+];
 
 /**
  * 이벤트 신청 후에 갱신되어야 합니다.
@@ -66,6 +79,7 @@ const refreshHostEventList = (code?: FieldCode) => {
 };
 
 const resetQueryKeys = {
+  all,
   applyEvent,
   cancelParticipantEvent,
   refreshLedgerList,

--- a/src/hooks/app/useAppState.ts
+++ b/src/hooks/app/useAppState.ts
@@ -18,7 +18,9 @@ export const useAppState = (
   settings?: AppStateHookSettings,
 ): AppStateHookResult => {
   const { onChange, onForeground, onBackground } = settings || {};
-  const [appState, setAppState] = useState(AppState.currentState);
+  const [appState, setAppState] = useState<AppStateStatus>(
+    AppState.currentState,
+  );
 
   useEffect(() => {
     const handleAppStateChange: Handler = (nextAppState) => {

--- a/src/hooks/app/useAppState.ts
+++ b/src/hooks/app/useAppState.ts
@@ -1,0 +1,43 @@
+/* eslint-disable no-unused-expressions */
+import { useState, useEffect } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+
+export interface AppStateHookSettings {
+  onChange?: (status: AppStateStatus) => void;
+  onForeground?: () => void;
+  onBackground?: () => void;
+}
+
+export interface AppStateHookResult {
+  appState: AppStateStatus;
+}
+
+type Handler = (state: AppStateStatus) => void;
+
+export const useAppState = (
+  settings?: AppStateHookSettings,
+): AppStateHookResult => {
+  const { onChange, onForeground, onBackground } = settings || {};
+  const [appState, setAppState] = useState(AppState.currentState);
+
+  useEffect(() => {
+    const handleAppStateChange: Handler = (nextAppState) => {
+      if (nextAppState === 'active' && appState !== 'active') {
+        onForeground && onForeground();
+      } else if (
+        appState === 'active' &&
+        nextAppState.match(/inactive|background/)
+      ) {
+        onBackground && onBackground();
+      }
+      setAppState(nextAppState);
+      onChange && onChange(nextAppState);
+    };
+
+    const listener = AppState.addEventListener('change', handleAppStateChange);
+
+    return () => listener.remove();
+  }, [onChange, onForeground, onBackground, appState]);
+
+  return { appState };
+};

--- a/src/hooks/app/useRefetchOnFocus.ts
+++ b/src/hooks/app/useRefetchOnFocus.ts
@@ -1,0 +1,17 @@
+import { useFocusEffect } from '@react-navigation/native';
+import { useCallback } from 'react';
+import { useAppState } from './useAppState';
+
+const useRefetchOnFocus = (refetch: () => void) => {
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, [refetch]),
+  );
+
+  useAppState({
+    onForeground: refetch,
+  });
+};
+
+export default useRefetchOnFocus;

--- a/src/hooks/eventMap/useMapCoordinateInfo.ts
+++ b/src/hooks/eventMap/useMapCoordinateInfo.ts
@@ -1,6 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { useQueryClient } from '@tanstack/react-query';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import useDialog from 'hooks/app/useDialog';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Platform } from 'react-native';

--- a/src/hooks/queries/banner.ts
+++ b/src/hooks/queries/banner.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import getBannerImages from 'apis/banner';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 
 // eslint-disable-next-line import/prefer-default-export
 export const useGetBannerImages = () => {

--- a/src/hooks/queries/bookmark.ts
+++ b/src/hooks/queries/bookmark.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { getBookmarkEventLists, updateBookmarkEvent } from 'apis/bookmark';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { ApiErrorResponse } from 'types/ApiResponse';
 
 export const useBookmarkEventLists = () => {

--- a/src/hooks/queries/comment.ts
+++ b/src/hooks/queries/comment.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { ApiErrorResponse } from 'types/ApiResponse';
 import {
   getChildComments,

--- a/src/hooks/queries/event.ts
+++ b/src/hooks/queries/event.ts
@@ -9,7 +9,7 @@ import {
   suspensionEvent,
 } from 'apis/eventInstance';
 import { FieldCode } from 'constants/interest';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { CreateNewEventRequestDto } from 'models/event/request/CreateNewEventRequestDto';
 import EventSearchRequestDto from 'models/event/request/EventSearchRequestDto';
 import { EventSuspensionRequestDto } from 'models/event/request/EventSuspensionRequestDto';

--- a/src/hooks/queries/interest.ts
+++ b/src/hooks/queries/interest.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { updateInterestField } from 'apis/interest';
 import fakeApi from 'apis/test';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import AddInterestRequestDto from 'models/field/request/AddInterestRequestDto';
 import { InterestInfoResponseDto } from 'models/interest/response/InterestInfoResponseDto';
 import { ApiErrorResponse } from 'types/ApiResponse';

--- a/src/hooks/queries/ledger.ts
+++ b/src/hooks/queries/ledger.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { ApiErrorResponse, ApiResponse } from 'types/ApiResponse';
 import { getHostEventLists } from 'apis/eventInstance';
 import { FieldCode } from 'constants/interest';

--- a/src/hooks/queries/user.ts
+++ b/src/hooks/queries/user.ts
@@ -10,7 +10,7 @@ import {
   uploadImages,
   uploadProfileImage,
 } from 'apis/user';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import AddInterestRequestDto from 'models/field/request/AddInterestRequestDto';
 import NCPSmsInfoRequestDto from 'models/user/request/NCPSmsInfoRequestDto';
 import { S3UploadServiceRequestDto } from 'models/user/request/S3UploadServiceRequestDto';

--- a/src/navigators/Navigator.tsx
+++ b/src/navigators/Navigator.tsx
@@ -4,6 +4,9 @@ import {
   createStackNavigator,
 } from '@react-navigation/stack';
 import BackButton from 'components/navigator/BackButton';
+import useResetQueries from 'hooks/queries/useResetQueries';
+import useRefetchOnFocus from 'hooks/app/useRefetchOnFocus';
+import resetQueryKeys from 'constants/queries/resetQueryKey';
 import { StackMenu } from 'constants/menu';
 import { Platform } from 'react-native';
 import DatePickScreen from 'screens/eventMap/DatePickScreen/DatePickScreen';
@@ -58,6 +61,9 @@ const Navigator = () => {
       color: 'transparent',
     },
   };
+
+  const { resetQueries } = useResetQueries();
+  useRefetchOnFocus(() => resetQueries(resetQueryKeys.all));
 
   return (
     <Stack.Navigator

--- a/src/screens/eventMap/DatePickScreen/DatePickScreen.tsx
+++ b/src/screens/eventMap/DatePickScreen/DatePickScreen.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import Text from 'components/common/Text/Text';
 import CalendarButton from 'components/eventMap/buttons/CalendarButton/CalendarButton';
 import CalendarCard from 'components/eventMap/cards/CalendarCard/CalendarCard';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { MarkedDates } from 'react-native-calendars/src/types';

--- a/src/screens/eventMap/EventMapScreen/EventMapScreen.tsx
+++ b/src/screens/eventMap/EventMapScreen/EventMapScreen.tsx
@@ -15,7 +15,7 @@ import CurrentMarker from 'components/eventMap/maps/CurrentMarker/CurrentMarker'
 import EventMarker from 'components/eventMap/maps/EventMarker/EventMarker';
 import MapBottomSheet from 'components/eventMap/sheets/MapBottomSheet/MapBottomSheet';
 import WithIconLoading from 'components/suspense/loading/WithIconLoading/WithIconLoading';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { SelectStatus } from 'constants/selectBox';
 import useEventListFormatter from 'hooks/eventMap/useEventListFormatter';
 import useEventMapSelector from 'hooks/eventMap/useEventMapSelector';

--- a/src/screens/events/EventCommentScreen/EventCommentScreen.tsx
+++ b/src/screens/events/EventCommentScreen/EventCommentScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { RefreshControl, ScrollView } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import MENT_EVENT_DETAIL from 'constants/eventDetail/eventDetailMessage';
 import { EventDetail } from 'components/eventDetail';
 import {

--- a/src/screens/events/EventDetailScreen/EventDetailScreen.tsx
+++ b/src/screens/events/EventDetailScreen/EventDetailScreen.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEventDetail } from 'hooks/queries/event';
 import useStackRoute from 'hooks/navigator/useStackRoute';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import SpaceLayout from 'components/layout/Space/SpaceLayout';
 import { EventDetail } from 'components/eventDetail';
 import MENT_EVENT_DETAIL from 'constants/eventDetail/eventDetailMessage';

--- a/src/screens/home/HomeScreen/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen/HomeScreen.tsx
@@ -9,6 +9,7 @@ import useNavigator from 'hooks/navigator/useNavigator';
 import useInterestFields from 'hooks/interest/useInterestFields';
 import { usePersonalEventLists, useVogueEventLists } from 'hooks/queries/event';
 import { useMyInfo } from 'hooks/queries/user';
+import useResetQueries from 'hooks/queries/useResetQueries';
 import { useCallback, useEffect } from 'react';
 import { Image, ScrollView, TouchableOpacity, View } from 'react-native';
 import { foregroundListener, requestAlarmPermission } from 'services/fcm';
@@ -45,8 +46,10 @@ const HomeScreen = () => {
     stackNavigation.navigate(StackMenu.Alert);
   };
 
+  const { resetQueries } = useResetQueries();
+
   const foregroundListenerCallback = useCallback(() => {
-    foregroundListener();
+    foregroundListener({ resetQueries });
   }, []);
 
   useEffect(() => {

--- a/src/screens/home/OpenEventScreen/OpenEventScreen.tsx
+++ b/src/screens/home/OpenEventScreen/OpenEventScreen.tsx
@@ -3,7 +3,7 @@ import { ScrollView } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { useOpenEventStore } from 'stores/OpenEventStore';
 import MENT_OPEN_EVENT from 'constants/openEvent/openEventConstants';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import KeyboardAvoidingScreenLayout from 'components/layout/KeyboardAvoidingScreenLayout/KeyboardAvoidingScreenLayout';
 import Spacing from 'components/common/Spacing/Spacing';
 import Divider from 'components/common/Divider/Divider';

--- a/src/screens/user/UserInterestResetScreen/UserInterestResetScreen.tsx
+++ b/src/screens/user/UserInterestResetScreen/UserInterestResetScreen.tsx
@@ -3,7 +3,7 @@ import ScreenCover from 'components/authorize/covers/ScreenCover/ScreenCover';
 import FieldButtonGroup from 'components/authorize/groups/FieldButtonGroup/FieldButtonGroup';
 import Spacing from 'components/common/Spacing/Spacing';
 import CommonLoading from 'components/suspense/loading/CommonLoading/CommonLoading';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import MENT_USER from 'constants/user/userConstants';
 import useDialog from 'hooks/app/useDialog';
 import useInterestField from 'hooks/authorize/useInterestField';

--- a/src/screens/userEvent/HostConsoleScreen/HostConsoleScreen.tsx
+++ b/src/screens/userEvent/HostConsoleScreen/HostConsoleScreen.tsx
@@ -14,7 +14,7 @@ import {
 import MENT_HOST from 'constants/userEvent/host/hostMessage';
 import API_ERROR_MESSAGE from 'constants/errorMessage';
 import { EventDetailTabItem } from 'constants/eventDetail/eventDetailConstants';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import { ConsoleScreenLayout } from 'components/userEvent/host/layout';
 import FixedButton from 'components/common/FixedButton/FixedButton';
 import Spacing from 'components/common/Spacing/Spacing';

--- a/src/screens/userEvent/HostLedgerScreen/HostLedgerScreen.tsx
+++ b/src/screens/userEvent/HostLedgerScreen/HostLedgerScreen.tsx
@@ -38,7 +38,7 @@ import useStackRoute from 'hooks/navigator/useStackRoute';
 import SortType from 'models/ledger/entity/SortType';
 import { ApiErrorResponse } from 'types/ApiResponse';
 import API_ERROR_MESSAGE from 'constants/errorMessage';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import resetQueryKeys from 'constants/queries/resetQueryKey';
 import WithIconLoading from 'components/suspense/loading/WithIconLoading/WithIconLoading';
 import ListLoading from 'components/suspense/loading/ListLoading/ListLoading';

--- a/src/screens/userEvent/HostQRScanScreen/HostQRScanScreen.tsx
+++ b/src/screens/userEvent/HostQRScanScreen/HostQRScanScreen.tsx
@@ -11,7 +11,7 @@ import MENT_HOST from 'constants/userEvent/host/hostMessage';
 import API_ERROR_MESSAGE from 'constants/errorMessage';
 import { StackMenu } from 'constants/menu';
 import { useCheckQR } from 'hooks/queries/ledger';
-import queryKeys from 'constants/queryKeys';
+import queryKeys from 'constants/queries/queryKeys';
 import WithIconLoading from 'components/suspense/loading/WithIconLoading/WithIconLoading';
 import { QRCheckResponseDto } from 'models/ledger/response/QRCheckResponseDto';
 import { colors } from 'styles/theme';

--- a/src/services/fcm.ts
+++ b/src/services/fcm.ts
@@ -4,6 +4,7 @@ import { permitAlert } from 'apis/user';
 import { Platform } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import { PERMISSIONS } from 'react-native-permissions';
+import resetQueryKeys from 'constants/queries/resetQueryKey';
 import { useAuthorizeStore } from 'stores/Authorize';
 import { requestSinglePermission } from './permission';
 
@@ -32,7 +33,6 @@ export const removeToken = async () => {
   }
 };
 
-// foreground alarm
 export const requestAlarmPermission = async () => {
   if (Platform.OS === 'ios') {
     const authorizationStatus = await messaging().requestPermission();
@@ -53,9 +53,11 @@ export const requestAlarmPermission = async () => {
 const handleDisplayNotification = async ({
   title = '',
   body = '',
+  resetQueries,
 }: {
   title?: string;
   body?: string;
+  resetQueries: (keys: Array<Array<string | number | undefined>>) => void;
 }) => {
   try {
     const channelId = await notifee.createChannel({
@@ -63,7 +65,7 @@ const handleDisplayNotification = async ({
       name: 'OpenOffChannel',
       importance: AndroidImportance.HIGH,
     });
-
+    resetQueries(resetQueryKeys.all);
     await notifee.displayNotification({
       title,
       body,
@@ -77,12 +79,16 @@ const handleDisplayNotification = async ({
   }
 };
 
-export const foregroundListener = () => {
+export const foregroundListener = ({
+  resetQueries,
+}: {
+  resetQueries: (keys: Array<Array<string | number | undefined>>) => void;
+}) => {
   try {
     messaging().onMessage(async (message) => {
       const title = message?.notification?.title;
       const body = message?.notification?.body;
-      handleDisplayNotification({ title, body });
+      handleDisplayNotification({ title, body, resetQueries });
     });
   } catch (e) {
     console.warn(e);


### PR DESCRIPTION
<!-- ⭐️ PR 제목은 아래 타입으로 시작하게 적어주세요 -->
<!-- feat, fix, chore, improvement, design, refactor, test, ci -->
<!-- EX) fix: 홈 화면 버그 수정 -->

### PR Type

<!-- 해당되는 것들을 제외하곤 지워주세요. -->

- 💫 기능추가

### OS별 테스트 여부

- [x] android
- [x] ios

### 작업 내용

<!-- 중점적으로 봐야 하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다. -->

- 앱 사용중 알림이 울릴시에 해당하는 데이터를 새로 불러올 수 있도록 함
- 앱이 background 상태에 있다가 돌아왔을 시에도 데이터를 새로 불러올 수 있도록 함

### 링크

<!-- 이슈 번호를 '#'뒤에 작성해주세요! (ex. resolved #11) -->

- resolved #136

### 기타 사항

<!-- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등이 있다면 자유롭게 적어주세요. -->

- background상태일 때 알림이 울릴 시에 queryClient를 사용할 수 없어서 useFocusEffect를 사용했습니다.
- 추후에 알림 타입에 따라서 해당하는 데이터만 refetch할 수 있도록 강화하면 좋을 것 같습니다!

<!-- assignees와 reviewers를 설정했는지 확인해주세요. -->
